### PR TITLE
Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,12 @@ machine:
 
 .PHONY: reinstall-machine01
 reinstall-machine01:
-	docker-compose run metalctl machine reinstall --image ubuntu-20.04 e0ab02d2-27cd-5a5e-8efc-080ba80cf258
+	docker-compose run metalctl machine reinstall --image ubuntu-19.10 e0ab02d2-27cd-5a5e-8efc-080ba80cf258
 	@$(MAKE) --no-print-directory reboot-machine01
 
 .PHONY: reinstall-machine02
 reinstall-machine02:
-	docker-compose run metalctl machine reinstall --image ubuntu-20.04 2294c949-88f6-5390-8154-fa53d93a3313
+	docker-compose run metalctl machine reinstall --image ubuntu-19.10 2294c949-88f6-5390-8154-fa53d93a3313
 	@$(MAKE) --no-print-directory reboot-machine02
 
 .PHONY: delete-machine01
@@ -97,12 +97,12 @@ delete-machine02:
 .PHONY: console-machine01
 console-machine01:
 	@echo "exit console with CTRL+5"
-	virsh console metal_machine01
+	virsh console metalmachine01
 
 .PHONY: console-machine02
 console-machine02:
 	@echo "exit console with CTRL+5"
-	virsh console metal_machine02
+	virsh console metalmachine02
 
 .PHONY: ls
 ls:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Small lab to setup the `metal-stack` locally. Starts two leaf switches and the [
 
 This requires:
 
-- vagrant >= 2.2.7 with vagrant-libvirt plugin >= 0.0.45 for running the switch and machine VMs
+- vagrant == 2.2.9 with vagrant-libvirt plugin >= 0.1.2 for running the switch and machine VMs
 - docker and docker-compose for using containerized `ansible` and `metalctl` and `helm`
 - kvm as hypervisor for the VMs
 - [ovmf](https://wiki.ubuntu.com/UEFI/OVMF) to have a uefi firmware for virtual machines
-- [kind](https://github.com/kubernetes-sigs/kind/releases) >= 0.7.0 to start the metal control-plane on a kubernetes cluster
+- [kind](https://github.com/kubernetes-sigs/kind/releases) == v0.8.1 to start the metal control-plane on a kubernetes cluster v1.18.2
 - (optional) haveged to have enough random entropy - only needed if the PXE process does not work
 
 Known limitations:

--- a/control-plane/requirements.yaml
+++ b/control-plane/requirements.yaml
@@ -4,4 +4,4 @@
   version: v0.5.2
 - src: https://github.com/metal-stack/metal-roles.git
   name: metal-roles
-  version: v0.1.11
+  version: update-fixes

--- a/control-plane/requirements.yaml
+++ b/control-plane/requirements.yaml
@@ -4,4 +4,4 @@
   version: v0.5.2
 - src: https://github.com/metal-stack/metal-roles.git
   name: metal-roles
-  version: update-fixes
+  version: v0.1.12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 
 services:
   control-plane:
-    image: metalstack/metal-deployment-base:v0.0.4
+    image: metalstack/metal-deployment-base:v0.0.5
     container_name: deploy-control-plane
     volumes:
       - /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock
@@ -29,7 +29,7 @@ services:
             control-plane.yaml
 
   partition:
-    image: metalstack/metal-deployment-base:v0.0.4
+    image: metalstack/metal-deployment-base:v0.0.5
     container_name: deploy-partition
     volumes:
       - ${HOME}/.vagrant.d:/root/.vagrant.d

--- a/group_vars/all/metal_api.yml
+++ b/group_vars/all/metal_api.yml
@@ -1,22 +1,16 @@
 ---
 # can be overriden of course, these are the global defaults...
 metal_api_images:
-- id: firewall-2
-  name: Firewall 2
-  description: Firewall 2
-  url: http://images.metal-pod.io/metal-os/firewall/2.0-ubuntu/20200317/img.tar.lz4
+- id: firewall-ubuntu-2.0.20200331
+  name: Firewall 2 Ubuntu 20200331
+  description: Firewall 2 Ubuntu 20200331
+  url: http://images.metal-pod.io/metal-os/firewall/2.0-ubuntu/20200331/img.tar.lz4
   features:
     - firewall
-- id: ubuntu-19.10
-  name: Ubuntu 19.10
-  description: Ubuntu 19.10
-  url: http://images.metal-pod.io/metal-os/ubuntu/19.10/20200317/img.tar.lz4
-  features:
-    - machine
-- id: ubuntu-20.04
-  name: Ubuntu 20.04
-  description: Ubuntu 20.04
-  url: http://images.metal-pod.io/metal-os/ubuntu/20.04/20200317/img.tar.lz4
+- id: ubuntu-19.10.20200331
+  name: Ubuntu 19.10 20200331
+  description: Ubuntu 19.10 20200331
+  url: http://images.metal-pod.io/metal-os/ubuntu/19.10/20200331/img.tar.lz4
   features:
     - machine
 

--- a/group_vars/minilab/images.yaml
+++ b/group_vars/minilab/images.yaml
@@ -1,5 +1,5 @@
 ---
-metal_api_image_tag: v0.7.4
+metal_api_image_tag: v0.7.5
 metal_metalctl_image_tag: v0.7.5
 metal_masterdata_api_image_tag: v0.7.1
 metal_console_image_tag: v0.4.1

--- a/group_vars/minilab/images.yaml
+++ b/group_vars/minilab/images.yaml
@@ -1,6 +1,6 @@
 ---
 metal_api_image_tag: v0.7.4
-metal_metalctl_image_tag: v0.7.7
+metal_metalctl_image_tag: v0.7.5
 metal_masterdata_api_image_tag: v0.7.1
 metal_console_image_tag: v0.4.1
 

--- a/group_vars/minilab/metal.yml
+++ b/group_vars/minilab/metal.yml
@@ -6,6 +6,7 @@ metal_api_replicas: 1
 metal_api_view_key: metal-view
 metal_api_edit_key: metal-edit
 metal_api_admin_key: metal-admin
+
 metal_api_sizes:
 - id: v1-small-x86
   name: v1-small-x86
@@ -20,15 +21,17 @@ metal_api_sizes:
   - type: storage
     min: "{{ '1GB' | humanfriendly }}"
     max: "{{ '10GB' | humanfriendly }}"
+
 metal_api_partitions:
   - id: vagrant
     name: Vagrant Lab
     description: The vagrant lab
     bootconfig:
-      kernelurl: https://images.metal-pod.io/metal-kernel/mainline/metal-hammer-kernel
+      kernelurl: https://github.com/metal-stack/kernel/releases/download/5.4.42-25/metal-kernel
       imageurl: "{{ metal_hammer_image_url }}"
       commandline: console=ttyS0,115200n8 ip=dhcp carrier_timeout=10
     privatenetworkprefixlength: 22
+
 metal_api_networks:
 - id: tenant-super-network-vagrant
   name: "Project Super Network"
@@ -66,6 +69,7 @@ metal_masterdata_api_tenants:
     group_config:
       namespace_max_length: 20
   description: FI-TS tenant, which is provider
+
 metal_masterdata_api_projects:
 - meta:
     id: 00000000-0000-0000-0000-000000000001


### PR DESCRIPTION
This PR strictly specifies the Vagrant version and Kind version to use.

Especially important is the Vagrant version because the Vagrant version on the host as well as in the deployment base image must be identical. Otherwise deployments will fail.

I also tested the mini-lab with the latest version of Kind 8.1, which we should also pin down as well. Otherwise, the mini-lab will stop working at some point in the future (leading to frustrating customer experience).

Also includes some updates here and there.