### PR TITLE
Bind 0.0.0.0 with control plane.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,18 @@ This project can also be used as a template for writing your own metal-stack dep
 Here is some code that should help you setting up most of the requirements:
 
  ```bash
-# Install vagrant
+# Install Docker
+curl -fsSL https://get.docker.com | sh
+# if you want to be on the safe side, follow the original installation
+# instructions at https://docs.docker.com/engine/install/ubuntu/
+
+# Install vagrant and other stuff
 wget https://releases.hashicorp.com/vagrant/2.2.9/vagrant_2.2.9_x86_64.deb
-apt-get install ./vagrant_2.2.9_x86_64.deb docker.io qemu-kvm virt-manager ovmf net-tools libvirt-dev haveged
+sudo apt-get install ./vagrant_2.2.9_x86_64.deb qemu-kvm virt-manager ovmf net-tools libvirt-dev haveged
 
 # Ensure that your user is member of the group "libvirt"
-usermod -G libvirt -a ${USER}
+# possibly you need to login again in order to make this change take effect
+sudo usermod -G libvirt -a ${USER}
 
 # Install libvirt plugin for vagrant
 vagrant plugin install vagrant-libvirt
@@ -48,14 +54,14 @@ vagrant plugin install vagrant-libvirt
 
 The following ports are getting used statically:
 
-| Port | Bind Address  | Description                        |
-|:----:|:-------------:|:---------------------------------- |
-| 8443 | 0.0.0.0       | kube-apiserver of the kind cluster |
-| 4443 | 192.168.121.1 | HTTPS ingress                      |
-| 4150 | 192.168.121.1 | nsqd                               |
-| 4161 | 192.168.121.1 | nsq-lookupd                        |
-| 5222 | 192.168.121.1 | metal-console                      |
-| 8080 | 192.168.121.1 | HTTP ingress                       |
+| Port | Bind Address | Description                        |
+|:----:|:------------ |:---------------------------------- |
+| 8443 |   0.0.0.0    | kube-apiserver of the kind cluster |
+| 4443 |   0.0.0.0    | HTTPS ingress                      |
+| 4150 |   0.0.0.0    | nsqd                               |
+| 4161 |   0.0.0.0    | nsq-lookupd                        |
+| 5222 |   0.0.0.0    | metal-console                      |
+| 8080 |   0.0.0.0    | HTTP ingress                       |
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -103,18 +103,15 @@ Create a machine with
 make machine
 ```
 
-or the hard way with
+or __as alternative__ the hard way with
 
 ```bash
 docker-compose run metalctl network allocate \
         --partition vagrant \
         --project 00000000-0000-0000-0000-000000000000 \
         --name vagrant
-```
 
-Lookup the network ID and run
-
-```bash
+# Lookup the network ID and run
 docker-compose run metalctl machine create \
         --description test \
         --name machine \
@@ -129,7 +126,7 @@ docker-compose run metalctl machine create \
 See the installation process in action
 
 ```bash
-virsh console metal_machine01/02
+virsh console metalmachine01/02
 ...
 Ubuntu 19.10 machine ttyS0
 

--- a/control-plane/kind.yaml
+++ b/control-plane/kind.yaml
@@ -8,16 +8,16 @@ nodes:
   extraPortMappings:
   - containerPort: 4443
     hostPort: 4443
-    listenAddress: 192.168.121.1
-  - containerPort: 8000
+    listenAddress: 0.0.0.0
+  - containerPort: 8080
     hostPort: 8080
-    listenAddress: 192.168.121.1
+    listenAddress: 0.0.0.0
   - containerPort: 4150
     hostPort: 4150
-    listenAddress: 192.168.121.1
+    listenAddress: 0.0.0.0
   - containerPort: 4161
     hostPort: 4161
-    listenAddress: 192.168.121.1
+    listenAddress: 0.0.0.0
   - containerPort: 10001
     hostPort: 5222
-    listenAddress: 192.168.121.1
+    listenAddress: 0.0.0.0

--- a/deploy_partition.yaml
+++ b/deploy_partition.yaml
@@ -46,6 +46,22 @@
 
 - name: deploy metal-core and pixiecore
   hosts: leaves
+  pre_tasks:
+    - name: add docker registry to hosts
+      lineinfile:
+        path: /etc/hosts
+        regexp: '{{ item.regex }}'
+        line: '{{ item.ip }} {{ item.name }}'
+        owner: root
+        group: root
+        mode: 0644
+      with_items:
+        - name: 0.0.0.0.xip.io
+          ip: "{{ metal_partition_mgmt_gateway }}"
+          regex: "{{ '0.0.0.0.xip.io' | regex_escape() }}"
+        - name: api.0.0.0.0.xip.io
+          ip: "{{ metal_partition_mgmt_gateway }}"
+          regex: "{{ 'api.0.0.0.0.xip.io' | regex_escape() }}"
   roles:
     - name: metal-roles/partition/roles/metal-core
       tags: metal-core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,6 @@ services:
     image: metalstack/metalctl:${METALCTL_IMAGE_TAG}
     environment:
       - METALCTL_HMAC=metal-admin
-      - METALCTL_URL=http://api.192.168.121.1.xip.io:8080/metal
+      - METALCTL_URL=http://api.0.0.0.0.xip.io:8080/metal
     network_mode: host
     command: --version

--- a/group_vars/control-plane/common.yaml
+++ b/group_vars/control-plane/common.yaml
@@ -1,7 +1,7 @@
 ---
 metal_control_plane_provider_tenant: metal-stack
 metal_control_plane_host_provider: vagrant
-metal_control_plane_ingress_dns: 192.168.121.1.xip.io
+metal_control_plane_ingress_dns: 0.0.0.0.xip.io
 metal_control_plane_stage_name: test
 metal_control_plane_namespace: metal-control-plane
 

--- a/group_vars/control-plane/metal.yml
+++ b/group_vars/control-plane/metal.yml
@@ -1,6 +1,6 @@
 ---
 metal_set_resource_limits: no
-metal_check_api_health_endpoint: http://api.192.168.121.1.xip.io:8080/metal/v1/health
+metal_check_api_health_endpoint: http://api.0.0.0.0.xip.io:8080/metal/v1/health
 
 metal_api_replicas: 1
 metal_api_view_key: metal-view

--- a/group_vars/partition/common.yaml
+++ b/group_vars/partition/common.yaml
@@ -3,7 +3,7 @@ metal_partition_timezone: Europe/Berlin
 metal_partition_id: vagrant
 
 metal_partition_metal_api_protocol: http
-metal_partition_metal_api_addr: api.192.168.121.1.xip.io
+metal_partition_metal_api_addr: api.0.0.0.0.xip.io
 metal_partition_metal_api_port: 8080
 metal_partition_metal_api_basepath: /metal/
 metal_partition_metal_api_hmac_edit_key: metal-edit

--- a/group_vars/partition/metal_core.yaml
+++ b/group_vars/partition/metal_core.yaml
@@ -4,6 +4,8 @@ metal_core_change_boot_order: false
 metal_core_nsq_tls_enabled: false
 
 metal_core_rack_id: test-rack
-metal_core_nsq_lookupd_addr: "192.168.121.1.xip.io:4161"
+metal_core_nsq_lookupd_addr: "0.0.0.0.xip.io:4161"
 
 metal_core_log_level: debug
+
+metal_core_consider_hosts_file_resolution: true

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -4,4 +4,4 @@
   version: v0.5.3
 - src: https://github.com/metal-stack/metal-roles.git
   name: metal-roles
-  version: v0.2.0
+  version: consider-hosts-file-resolution

--- a/roles/ingress-controller/defaults/main.yaml
+++ b/roles/ingress-controller/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-ingress_http_port: 8000
+ingress_http_port: 8080
 ingress_https_port: 4443

--- a/roles/ingress-controller/templates/service.yaml
+++ b/roles/ingress-controller/templates/service.yaml
@@ -8,10 +8,10 @@ spec:
   type: ClusterIP
   ports:
     - name: http
-      port: 80
+      port: {{ ingress_http_port }}
       targetPort: http
     - name: https
-      port: 4443
+      port: {{ ingress_https_port }}
       targetPort: https
   selector:
     app.kubernetes.io/name: ingress-nginx


### PR DESCRIPTION
This removes the requirement of having the 192.168.121.1 interface when spinning up the control plane.

This resolves #5. I would assume it makes more sense to do it this way than proposed in https://github.com/metal-stack/mini-lab/pull/14 because some people do not even want to have Vagrant / KVM installed in order to only spin up the control plane (for example for developing the metal-api).

Additionally, the PR adds the following minor improvements:
- Creates a kind cluster with the name `metal-control-plane` instead of default name, which allows checking if the cluster was already created
- Checks if kind is installed
- Small improvements on installation instructions
- Fixes an issue with the ingress controller service, which was not using the actual HTTP and HTTPS ports