### PR TITLE
More robust check of host vagrant version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ansible_vagrant_cache
+.vagrant_version_host_system
 .env
 .idea
 .kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ control-plane: control-plane-bake
 
 .PHONY: partition-bake
 partition-bake:
+ifeq (,$(wildcard ./.vagrant_version_host_system))
+	@vagrant version | grep "Installed Version" | cut -d: -f 2 | tr -d '[:space:]' > .vagrant_version_host_system
+endif
 	vagrant up
 
 .PHONY: partition
@@ -42,6 +45,7 @@ cleanup: caddy-down registry-down
 	kind delete cluster --name metal-control-plane
 	docker-compose down
 	rm -f $(KUBECONFIG)
+	rm -f .vagrant_version_host_system
 	rm -f .ansible_vagrant_cache
 
 .PHONY: dev-env

--- a/deploy_partition.yaml
+++ b/deploy_partition.yaml
@@ -10,9 +10,9 @@
 
     - name: check vagrant version
       fail:
-        msg: "Vagrant version of the host system does not match vagrant version in the deployment image"
+        msg: "Vagrant version of the host system ({{ lookup('file', playbook_dir + '/.vagrant_version_host_system') }}) does not match vagrant version in the deployment image ({{ result.stdout.split(' ')[1] }})"
       when:
-        - result.stdout.split(' ')[1] != (lookup('file', playbook_dir + '/.vagrant/bundler/global.sol') | from_json).vagrant_version
+        - result.stdout.split(' ')[1] != lookup('file', playbook_dir + '/.vagrant_version_host_system')
 
 - name: deploy leaves and docker
   hosts: leaves


### PR DESCRIPTION
On some environments the folder `.vagrant/bundler/global.sol` seems to be unpresent.