### PR TITLE
Fix for nsq broadcast address regression.

### DIFF
--- a/deploy_partition.yaml
+++ b/deploy_partition.yaml
@@ -66,6 +66,9 @@
         - name: api.0.0.0.0.xip.io
           ip: "{{ metal_partition_mgmt_gateway }}"
           regex: "{{ 'api.0.0.0.0.xip.io' | regex_escape() }}"
+        - name: nsqd
+          ip: "{{ metal_partition_mgmt_gateway }}"
+          regex: "{{ 'nsqd' | regex_escape() }}"
   roles:
     - name: ansible-common
       tags: always

--- a/group_vars/control-plane/metal.yml
+++ b/group_vars/control-plane/metal.yml
@@ -7,6 +7,8 @@ metal_api_view_key: metal-view
 metal_api_edit_key: metal-edit
 metal_api_admin_key: metal-admin
 
+metal_api_nsq_tcp_address: nsqd:4150
+
 metal_api_images:
 - id: firewall-ubuntu-2.0.20200331
   name: Firewall 2 Ubuntu 20200331

--- a/group_vars/control-plane/nsq.yaml
+++ b/group_vars/control-plane/nsq.yaml
@@ -4,3 +4,5 @@ nsq_set_resource_limits: no
 nsq_log_level: debug
 
 nsq_tls_enabled: false
+
+nsq_broadcast_address: nsqd


### PR DESCRIPTION
This was causing the metal-api not to properly connect to NSQ anymore and was introduced when we were switching everything to 0.0.0.0.xip.io in #17.