### PR TITLE
Update to metal-stack v0.1.2 and dynamically obtain requirements.yaml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 ansible-common
 metal-hammer*
 partition/dynamic_inventory.yaml
+requirements.yaml

--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,7 @@ registry: registry-down
 
 .PHONY: reload-api
 reload-api: build-api-image load-api-image
-	$(eval pod = $(shell kubectl --kubeconfig=$(KUBECONFIG) --namespace metal-control-plane get pod | grep metal-api | head -1|cut -d' ' -f1))
-	kubectl --kubeconfig=$(KUBECONFIG) --namespace metal-control-plane delete pod $(pod)
+	kubectl --kubeconfig=$(KUBECONFIG) --namespace metal-control-plane delete pod -l app=metal-api
 
 .PHONY: build-api-image
 build-api-image:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       - /bin/bash
       - -ce
       - |
+          ansible-playbook \
+            -i inventories/control-plane.yaml \
+            obtain_role_requirements.yaml
           ansible-galaxy install --ignore-errors -r requirements.yaml
           ansible-playbook \
             -i inventories/control-plane.yaml \
@@ -51,6 +54,9 @@ services:
       - /bin/bash
       - -ce
       - |
+          ansible-playbook \
+            -i inventories/control-plane.yaml \
+            obtain_role_requirements.yaml
           ansible-galaxy install --ignore-errors -r requirements.yaml
           ansible-playbook \
             -i inventories/partition-static.yaml \

--- a/group_vars/all/images.yaml
+++ b/group_vars/all/images.yaml
@@ -1,2 +1,2 @@
 ---
-metal_stack_release_version: v0.1.1
+metal_stack_release_version: v0.1.2

--- a/group_vars/partition/metal_core.yaml
+++ b/group_vars/partition/metal_core.yaml
@@ -1,5 +1,4 @@
 ---
-metal_core_image_tag: v0.5.3
 metal_core_change_boot_order: false
 
 metal_core_nsq_tls_enabled: false

--- a/obtain_role_requirements.yaml
+++ b/obtain_role_requirements.yaml
@@ -1,0 +1,23 @@
+---
+- name: provide requirements.yaml
+  hosts: control-plane
+  connection: local
+  gather_facts: false
+  vars:
+    release_vector_url: https://raw.githubusercontent.com/metal-stack/releases/{{ metal_stack_release_version }}/release.yaml
+  tasks:
+    - name: download release vector
+      uri:
+        url: "{{ release_vector_url }}"
+        return_content: yes
+      register: release_vector
+
+    - name: write requirements.yaml from release vector
+      copy:
+        dest: "{{ playbook_dir }}/requirements.yaml"
+        content: |
+          {% for role_name, role_params in (release_vector.content | from_yaml).get('ansible-roles').items() %}
+          - src: {{ role_params.get('repository') }}
+            name: {{ role_name }}
+            version: {{ role_params.get('version') }}
+          {% endfor %}

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,7 +1,0 @@
----
-- src: https://github.com/metal-stack/ansible-common.git
-  name: ansible-common
-  version: v0.5.4
-- src: https://github.com/metal-stack/metal-roles.git
-  name: metal-roles
-  version: v0.3.0


### PR DESCRIPTION
This way, we do not need to update the `requirements.yaml` anymore. It's still possible to just override the paths with local paths because ansible-galaxy will not overwrite existing directories.