### PR TITLE
Fix flaky ssh access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ _ips:
 	$(eval dev = $(shell virsh net-info vagrant-libvirt | grep Bridge | cut -d' ' -f10 2>/dev/null))
 	$(eval ipL1 = $(shell python3 -c 'import pickle; print(pickle.load(open(".ansible_vagrant_cache", "rb"))["meta_vars"]["leaf01"]["ansible_host"])'))
 	$(eval ipL2 = $(shell python3 -c 'import pickle; print(pickle.load(open(".ansible_vagrant_cache", "rb"))["meta_vars"]["leaf02"]["ansible_host"])'))
-	$(eval staticR = "100.255.254.0/24 nexthop via $(ipL1) dev $(dev)")
+	$(eval staticR = "100.255.254.0/24 nexthop via $(ipL1) dev $(dev) nexthop via $(ipL2) dev $(dev)")
 
 .PHONY: reload-core
 reload-core: build-core-image push-core-image _ips

--- a/roles/internet/tasks/main.yaml
+++ b/roles/internet/tasks/main.yaml
@@ -12,3 +12,15 @@
       - vniInternet
     metal_core_additional_bridge_vids:
       - 4009
+
+# This removes firewall/SNAT state on both leaves(!) for the virtual internet network
+# Otherwise this could happen:
+# - local machine uses route to leaf01 for a request
+# - the answer from a machine may be send over leaf02 (because of asymmetric routing)
+# - leaf02 does not have a state for this connection => drops the response
+
+- name: delete common masquerade rule
+  command: iptables -t nat -D POSTROUTING 2
+
+- name: add masquerade rule that skips virtual internet network
+  command: iptables -t nat -A POSTROUTING ! -s 100.255.254.0/24 -o eth0 -j MASQUERADE

--- a/test.sh
+++ b/test.sh
@@ -51,8 +51,7 @@ sudo ip r d 100.255.254.0/24 || true
 $(make route) || true
 
 echo "Check if SSH login to firewall works"
-# FIXME: lead to unstable integration tests, disabling for now.
-# ssh -o StrictHostKeyChecking=no metal@100.255.254.1 -C exit
+ssh -o StrictHostKeyChecking=no metal@100.255.254.1 -C exit
 
 echo "Successfully started mini-lab"
 sudo ip r d 100.255.254.0/24


### PR DESCRIPTION
This removes firewall/SNAT state on both leaves(!) for the virtual internet network

Otherwise this could happen:
- local machine uses route to leaf01 for a request
- the answer from a machine may be send over leaf02 (because of asymmetric routing)
- leaf02 does not have a state for this connection => drops the response

closes #37 