### PR TITLE
added support for VAGRANT_HOME env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     image: metalstack/metal-deployment-base:${DEPLOYMENT_BASE_IMAGE_TAG}
     container_name: deploy-partition
     volumes:
-      - ${HOME}/.vagrant.d:/root/.vagrant.d
+      - ${VAGRANT_HOME:-~/.vagrant.d}:/root/.vagrant.d
       - /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/mini-lab


### PR DESCRIPTION
Fixes https://github.com/metal-stack/mini-lab/issues/43

Added support for [VAGRANT_HOME](https://www.vagrantup.com/docs/other/environmental-variables.html#vagrant_home) env var. With default setting to `~/.vagrant.d`(suprisingly, `~` expansion is actually [part of POSIX now](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_01), so there shouldn't be any problems with using it(probably))

Reason, why i didn't use `HOME` env var is because it looks like [`docker-compose` has problem with nested env var expansion](https://github.com/docker/compose/issues/7884).