### PR TITLE
Use .nip.io instead of .xip.io.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ cleanup: caddy-down registry-down
 
 .PHONY: dev-env
 dev-env:
-	@echo "export METALCTL_URL=http://api.0.0.0.0.xip.io:8080/metal"
+	@echo "export METALCTL_URL=http://api.0.0.0.0.nip.io:8080/metal"
 	@echo "export METALCTL_HMAC=metal-admin"
 	@echo "export KUBECONFIG=$(KUBECONFIG)"
 

--- a/deploy_partition.yaml
+++ b/deploy_partition.yaml
@@ -60,12 +60,12 @@
         group: root
         mode: 0644
       with_items:
-        - name: 0.0.0.0.xip.io
+        - name: 0.0.0.0.nip.io
           ip: "{{ metal_partition_mgmt_gateway }}"
-          regex: "{{ '0.0.0.0.xip.io' | regex_escape() }}"
-        - name: api.0.0.0.0.xip.io
+          regex: "{{ '0.0.0.0.nip.io' | regex_escape() }}"
+        - name: api.0.0.0.0.nip.io
           ip: "{{ metal_partition_mgmt_gateway }}"
-          regex: "{{ 'api.0.0.0.0.xip.io' | regex_escape() }}"
+          regex: "{{ 'api.0.0.0.0.nip.io' | regex_escape() }}"
         - name: nsqd
           ip: "{{ metal_partition_mgmt_gateway }}"
           regex: "{{ 'nsqd' | regex_escape() }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     image: ghcr.io/metal-stack/metalctl:${METALCTL_IMAGE_TAG}
     environment:
       - METALCTL_HMAC=metal-admin
-      - METALCTL_URL=http://api.0.0.0.0.xip.io:8080/metal
+      - METALCTL_URL=http://api.0.0.0.0.nip.io:8080/metal
     volumes:
       - ${HOME}/.ssh:/root/.ssh:ro
     network_mode: host

--- a/inventories/group_vars/control-plane/common.yaml
+++ b/inventories/group_vars/control-plane/common.yaml
@@ -1,7 +1,7 @@
 ---
 metal_control_plane_provider_tenant: metal-stack
 metal_control_plane_host_provider: vagrant
-metal_control_plane_ingress_dns: 0.0.0.0.xip.io
+metal_control_plane_ingress_dns: 0.0.0.0.nip.io
 metal_control_plane_stage_name: test
 metal_control_plane_namespace: metal-control-plane
 metal_control_plane_image_pull_policy: Always

--- a/inventories/group_vars/control-plane/metal.yml
+++ b/inventories/group_vars/control-plane/metal.yml
@@ -1,6 +1,6 @@
 ---
 metal_set_resource_limits: no
-metal_check_api_health_endpoint: http://api.0.0.0.0.xip.io:8080/metal/v1/health
+metal_check_api_health_endpoint: http://api.0.0.0.0.nip.io:8080/metal/v1/health
 
 # metal_helm_chart_local_path: /helm-charts/charts/metal-control-plane
 

--- a/inventories/group_vars/partition/common.yaml
+++ b/inventories/group_vars/partition/common.yaml
@@ -3,7 +3,7 @@ metal_partition_timezone: Europe/Berlin
 metal_partition_id: vagrant
 
 metal_partition_metal_api_protocol: http
-metal_partition_metal_api_addr: api.0.0.0.0.xip.io
+metal_partition_metal_api_addr: api.0.0.0.0.nip.io
 metal_partition_metal_api_port: 8080
 metal_partition_metal_api_basepath: /metal/
 metal_partition_metal_api_hmac_edit_key: metal-edit

--- a/inventories/group_vars/partition/metal_core.yaml
+++ b/inventories/group_vars/partition/metal_core.yaml
@@ -4,7 +4,7 @@ metal_core_change_boot_order: false
 metal_core_nsq_tls_enabled: false
 
 metal_core_rack_id: test-rack
-metal_core_nsq_lookupd_addr: "0.0.0.0.xip.io:4161"
+metal_core_nsq_lookupd_addr: "0.0.0.0.nip.io:4161"
 
 metal_core_log_level: debug
 


### PR DESCRIPTION
.xip.io is down and it's not so clear if it will come back. :/ 
Maybe we should move to .nip.io instead.