### PR TITLE
increase machine /var/lib size

### DIFF
--- a/inventories/group_vars/control-plane/metal_fsl.yaml
+++ b/inventories/group_vars/control-plane/metal_fsl.yaml
@@ -38,7 +38,7 @@ metal_api_filesystemlayouts:
           gpttype: "ef00"
         - number: 2
           label: "root"
-          size: 5000
+          size: 4500
           gpttype: "8300"
         - number: 3
           label: "varlib"


### PR DESCRIPTION
By default docekr uses /var/lib/docker as storage directory. New default filesystem layout gives insufficient space to /var/lib for testing Cluster API provider. This commit increases /var/lib space by reducing root size.

cc @Gerrit91 