### PR TITLE
Additional ingress config and allow passing extra vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ clab-mini-lab
 ansible-common
 metal-hammer*
 requirements.yaml
+.extra_vars.yaml

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ KUBECONFIG := $(shell pwd)/.kubeconfig
 # Default values
 DOCKER_COMPOSE_OVERRIDE=
 
+# extra vars can be used by projects that built on the mini-lab, which want to override default configuration
+ANSIBLE_EXTRA_VARS_FILE := $(or $(ANSIBLE_EXTRA_VARS_FILE),)
+
 MINI_LAB_FLAVOR := $(or $(MINI_LAB_FLAVOR),default)
 MINI_LAB_VM_IMAGE := $(or $(MINI_LAB_VM_IMAGE),ghcr.io/metal-stack/mini-lab-vms:latest)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
           ansible-galaxy install --ignore-errors -r requirements.yaml
           ansible-playbook \
             -i inventories/control-plane.yaml \
-            deploy_control_plane.yaml
+            deploy_control_plane.yaml --extra-vars "@.extra_vars.yaml"
 
   partition:
     image: ghcr.io/metal-stack/metal-deployment-base:${DEPLOYMENT_BASE_IMAGE_TAG}
@@ -73,7 +73,7 @@ services:
           ansible-playbook \
             -i inventories/partition.yaml \
             -i clab-mini-lab/ansible-inventory.yml \
-            deploy_partition.yaml
+            deploy_partition.yaml --extra-vars "@.extra_vars.yaml"
 
   metalctl:
     image: ghcr.io/metal-stack/metalctl:${METALCTL_IMAGE_TAG}

--- a/env.sh
+++ b/env.sh
@@ -13,6 +13,11 @@ RELEASE_YAML=$(curl -s https://raw.githubusercontent.com/metal-stack/releases/${
 METALCTL_IMAGE_TAG=$(yq_shell "echo \"${RELEASE_YAML}\" | yq r - docker-images.metal-stack.control-plane.metalctl.tag")
 DEPLOYMENT_BASE_IMAGE_TAG=$(yq_shell "echo \"${RELEASE_YAML}\" | yq r - docker-images.metal-stack.generic.deployment-base.tag")
 
+echo "{}" > .extra_vars.yaml
+if [ ! -z ${ANSIBLE_EXTRA_VARS_FILE} ]; then
+  cat ${ANSIBLE_EXTRA_VARS_FILE} > .extra_vars.yaml || echo "{}" > .extra_vars.yaml
+fi
+
 cat << EOF > .env
 METALCTL_IMAGE_TAG=${METALCTL_IMAGE_TAG}
 DEPLOYMENT_BASE_IMAGE_TAG=${DEPLOYMENT_BASE_IMAGE_TAG}

--- a/inventories/group_vars/control-plane/metal.yml
+++ b/inventories/group_vars/control-plane/metal.yml
@@ -73,6 +73,9 @@ metal_api_networks:
   vrf: 104009
   prefixes:
   - 100.255.254.0/24
+  labels:
+    network.metal-stack.io/default: ""
+    network.metal-stack.io/default-external: ""
 - id: underlay-mini-lab
   name: "Underlay Network"
   description: "Underlay Network for mini-lab"

--- a/roles/ingress-controller/defaults/main.yaml
+++ b/roles/ingress-controller/defaults/main.yaml
@@ -2,5 +2,4 @@
 ingress_http_port: 8080
 ingress_https_port: 4443
 
-ingress_additional_config:
-  large-client-header-buffers: 4 32k
+ingress_additional_config: {}

--- a/roles/ingress-controller/defaults/main.yaml
+++ b/roles/ingress-controller/defaults/main.yaml
@@ -1,3 +1,5 @@
 ---
 ingress_http_port: 8080
 ingress_https_port: 4443
+
+ingress_additional_config: {}

--- a/roles/ingress-controller/defaults/main.yaml
+++ b/roles/ingress-controller/defaults/main.yaml
@@ -2,4 +2,5 @@
 ingress_http_port: 8080
 ingress_https_port: 4443
 
-ingress_additional_config: {}
+ingress_additional_config:
+  large-client-header-buffers: 4 32k

--- a/roles/ingress-controller/templates/values.yaml
+++ b/roles/ingress-controller/templates/values.yaml
@@ -29,6 +29,8 @@ controller:
   metrics:
     enabled: false
 
+  config: {{ ingress_additional_config | to_json }}
+
 tcp:
   4161: "{{ metal_control_plane_namespace }}/nsq-lookupd:4161"
   4150: "{{ metal_control_plane_namespace }}/nsqd:4150"


### PR DESCRIPTION
This PR provides the opportunity to add additional configuration to the ingress-controller deployment. Also, this can be provided through extra vars that can optionally be passed through a file reference in an environment variable. This way, an external project that is using the mini-lab (e.g. as a submodule) can parametrize the deployment without modifying the repo sources.