### PR TITLE
Use host CPU capabilities to get rid of some CPU related warnings from QEMU

### DIFF
--- a/scripts/manage_vms.py
+++ b/scripts/manage_vms.py
@@ -133,6 +133,7 @@ class Manager:
             "-uuid", machine.get("uuid"),
             "-m", machine.get("memory"),
             "-boot", "n",
+            "-cpu", "host",
             "-drive", "if=virtio,format=qcow2,file={disk}".format(disk=machine.get("disk-path")),
             "-drive", "if=pflash,format=raw,readonly,file=/usr/share/OVMF/OVMF_CODE.fd",
             "-drive", "if=pflash,format=raw,file=/usr/share/OVMF/OVMF_VARS.fd",


### PR DESCRIPTION
The PR removes the warning 
`(qemu) qemu-system-x86_64: warning: host doesn't support requested feature: CPUID.80000001H:ECX.svm [bit 2]`
on my machine.