### PR TITLE
Use `which` instead of `command -v` in CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ KUBECONFIG := $(shell pwd)/.kubeconfig
 
 # Default values
 DOCKER_COMPOSE_OVERRIDE=
-DOCKER_COMPOSE=$(shell if command -v docker-compose > /dev/null; then echo 'docker-compose'; else echo 'docker compose'; fi)
-CONTAINERLAB=$(shell command -v containerlab)
+DOCKER_COMPOSE=$(shell if which docker-compose > /dev/null; then echo 'docker-compose'; else echo 'docker compose'; fi)
+CONTAINERLAB=$(shell which containerlab)
 
 # extra vars can be used by projects that built on the mini-lab, which want to override default configuration
 ANSIBLE_EXTRA_VARS_FILE := $(or $(ANSIBLE_EXTRA_VARS_FILE),)


### PR DESCRIPTION
For some reason the built-in command `command` does not work on our CI runners:

```
Cleanup artifacts of previous runs
kind delete cluster --name metal-control-plane
make: command: Command not found
Deleting cluster "metal-control-plane" ...
docker-compose down
time="2022-11-10T0[9](https://github.com/metal-stack/mini-lab/actions/runs/3435611575/jobs/5728171911#step:6:10):37:00Z" level=warning msg="The \"DEPLOYMENT_BASE_IMAGE_TAG\" variable is not set. Defaulting to a blank string."
time="2022-11-[10](https://github.com/metal-stack/mini-lab/actions/runs/3435611575/jobs/5728171911#step:6:11)T09:37:00Z" level=warning msg="The \"DEPLOYMENT_BASE_IMAGE_TAG\" variable is not set. Defaulting to a blank string."
time="2022-11-10T09:37:00Z" level=warning msg="The \"METALCTL_IMAGE_TAG\" variable is not set. Defaulting to a blank string."
Warning: No resource found to remove for project "mini-lab".
rm -f /home/github-runner/actions-runner/_work/mini-lab/mini-lab/.kubeconfig
make: command: Command not found
sudo  destroy --topo mini-lab.cumulus.yaml
make: command: Command not found
sudo: destroy: command not found
make: *** [Makefile:[12](https://github.com/metal-stack/mini-lab/actions/runs/3435611575/jobs/5728171911#step:6:13)2: ...
```

Looks like there is a different shell context which does not have the built-ins. Also other people seem to have this issue when you google the issue. :/