### PR TITLE
Enable SSL passthrough in ingress-controller.

### DIFF
--- a/roles/ingress-controller/templates/values.yaml
+++ b/roles/ingress-controller/templates/values.yaml
@@ -9,6 +9,7 @@ controller:
   extraArgs:
     http-port: {{ ingress_http_port }}
     https-port: {{ ingress_https_port }}
+    enable-ssl-passthrough: ""
 
   daemonset:
     useHostPort: true


### PR DESCRIPTION
This allows creating ingress resources with GRPC backend-protocol where TLS can be terminated on the application server. 

We use this for metalstack.cloud and can think about using this instead of TCP service exposal for our grpc-server in the metal-api as well.