### PR TITLE
Auditing with Meilisearch

### DIFF
--- a/deploy_control_plane.yaml
+++ b/deploy_control_plane.yaml
@@ -22,5 +22,7 @@
       tags: ipam-db
     - name: metal-roles/control-plane/roles/masterdata-db
       tags: masterdata-db
+    - name: metal-roles/control-plane/roles/auditing-meili
+      tags: auditing
     - name: metal-roles/control-plane/roles/metal
       tags: metal

--- a/inventories/group_vars/all/images.yaml
+++ b/inventories/group_vars/all/images.yaml
@@ -24,5 +24,5 @@ metal_stack_release_version: v0.11.0
 ##
 
 # ansible_common_version:
-# metal_roles_version:
+metal_roles_version: feature/auditing
 # metal_ansible_modules_version:

--- a/inventories/group_vars/all/images.yaml
+++ b/inventories/group_vars/all/images.yaml
@@ -1,5 +1,5 @@
 ---
-metal_stack_release_version: auditing
+metal_stack_release_version: develop
 
 ##
 ## for development purposes, you can override releases from our image vector here

--- a/inventories/group_vars/all/images.yaml
+++ b/inventories/group_vars/all/images.yaml
@@ -24,5 +24,5 @@ metal_stack_release_version: develop
 ##
 
 # ansible_common_version:
-metal_roles_version: feature/auditing
+# metal_roles_version:
 # metal_ansible_modules_version:

--- a/inventories/group_vars/all/images.yaml
+++ b/inventories/group_vars/all/images.yaml
@@ -1,5 +1,5 @@
 ---
-metal_stack_release_version: v0.11.0
+metal_stack_release_version: auditing
 
 ##
 ## for development purposes, you can override releases from our image vector here

--- a/inventories/group_vars/control-plane/auditing.yaml
+++ b/inventories/group_vars/control-plane/auditing.yaml
@@ -1,10 +1,12 @@
 ---
 metal_auditing_enabled: true
-metal_auditing_secret: "secret"
-metal_meilisearch_ingress:
+metal_auditing_meili_secret: "secret"
+
+metal_auditing_meili_chart_version: "0.1.44"
+metal_auditing_meili_ingress:
   enabled: true
   hosts:
-    - mtl-auditing.172.17.0.1.nip.io
-metal_meilisearch_persistence:
+    - auditing.172.17.0.1.nip.io
+metal_auditing_meili_persistence:
   enabled: true
   size: 10Gi

--- a/inventories/group_vars/control-plane/auditing.yaml
+++ b/inventories/group_vars/control-plane/auditing.yaml
@@ -1,8 +1,8 @@
 ---
 metal_auditing_enabled: true
-metal_auditing_meili_secret: "secret"
+metal_auditing_meili_secret: "geheim"
+metal_auditing_meili_environment: development
 
-metal_auditing_meili_chart_version: "0.1.44"
 metal_auditing_meili_ingress:
   enabled: true
   hosts:

--- a/inventories/group_vars/control-plane/auditing.yaml
+++ b/inventories/group_vars/control-plane/auditing.yaml
@@ -1,12 +1,12 @@
 ---
-metal_auditing_enabled: true
-metal_auditing_meili_secret: "geheim"
-metal_auditing_meili_environment: development
+auditing_meili_secret: geheim
+auditing_meili_environment: development
 
-metal_auditing_meili_ingress:
+auditing_meili_ingress:
   enabled: true
   hosts:
-    - auditing.172.17.0.1.nip.io
-metal_auditing_meili_persistence:
+    - auditing.{{ metal_control_plane_ingress_dns }}
+
+auditing_meili_persistence:
   enabled: true
   size: 10Gi

--- a/inventories/group_vars/control-plane/auditing.yaml
+++ b/inventories/group_vars/control-plane/auditing.yaml
@@ -1,0 +1,10 @@
+---
+metal_auditing_enabled: true
+metal_auditing_secret: "secret"
+metal_meilisearch_ingress:
+  enabled: true
+  hosts:
+    - mtl-auditing.172.17.0.1.nip.io
+metal_meilisearch_persistence:
+  enabled: true
+  size: 10Gi

--- a/inventories/group_vars/control-plane/metal.yml
+++ b/inventories/group_vars/control-plane/metal.yml
@@ -122,3 +122,7 @@ metal_api_grpc_certs_server_cert: "{{  lookup('file', 'certs/grpc/server.pem') }
 metal_api_grpc_certs_client_key: "{{ lookup('file', 'certs/grpc/client-key.pem') }}"
 metal_api_grpc_certs_client_cert: "{{  lookup('file', 'certs/grpc/client.pem') }}"
 metal_api_grpc_certs_ca_cert: "{{ lookup('file', 'certs/ca.pem') }}"
+
+# auditing
+metal_auditing_enabled: true
+metal_auditing_index_prefix: metal


### PR DESCRIPTION
Implements auditing with Meilisearch https://github.com/metal-stack-cloud/docs/issues/33.
More details can be found in [MEP11](https://docs.metal-stack.io/stable/development/proposals/MEP11/README/).
Does not implement the sidecar for the s3 sync.

Consists of multiple PRs:

- https://github.com/metal-stack/helm-charts/pull/53
- https://github.com/metal-stack/mini-lab/pull/132
- https://github.com/metal-stack/metal-api/pull/372
- https://github.com/metal-stack/metal-roles/pull/113
- https://github.com/metal-stack/metal-lib/pull/66

1. Clone all of these and check out `feature/auditing` to get started testing.
2. in `mini-lab/docker-compose.yaml` add volumes to `control-plane` and `partition`.

```yaml
      # adjust the paths to your actual repo locations
      - ${HOME}/dev/ms/helm-charts:/helm-charts:ro
      - ${HOME}/dev/ms/metal-roles:/root/.ansible/roles/metal-roles:ro
```

3. in `mini-lab/inventories/group_vars/control-plane/metal.yml` uncomment `metal_helm_chart_local_path: /helm-charts/charts/metal-control-plane`
4. in mini-lab, run `make up` and wait
5. in metal-api, run `make mini-lab-push` and wait
6. Run `kubectl get pods -n metal-control-plane --watch` and wait for all pods to be running or completed
7. in mini-lab run `make firewall`
8. in mini-lab run `make machine`
9. open http://mtl-auditing.172.17.0.1.nip.io:8080/ and enter the secret from mini-lab (default `metal_auditing_secret: "secret"`)
10. You should see some logs from GRPC and Rest calls

If a request fails, copy the rqid from your logs and paste them in qoutes into meilisearch. You should now see exactly two results!