### PR TITLE
fix(auditing): explicitly clear out storage class

### DIFF
--- a/inventories/group_vars/control-plane/auditing.yaml
+++ b/inventories/group_vars/control-plane/auditing.yaml
@@ -10,3 +10,4 @@ auditing_meili_ingress:
 auditing_meili_persistence:
   enabled: true
   size: 10Gi
+  storageClass: null


### PR DESCRIPTION
Requires https://github.com/metal-stack/metal-roles/pull/188 (otherwise `null` will be inserted as Python's `None`)

Fixes https://github.com/metal-stack/releases/actions/runs/5410672817

`PersistentVolumeClaim is not bound: auditing/auditing-meili-meilisearch`

