### PR TITLE
docs: pin containerlab install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ curl -fsSL https://get.docker.com | sh
 sudo usermod -G docker -a ${USER}
 
 # Install containerlab
-bash -c "$(curl -sL https://get.containerlab.dev)"
+bash -c "$(curl -sL https://get.containerlab.dev)" -- -v 0.25.1
 
 # Install kind (kubernetes in docker), for more details see https://kind.sigs.k8s.io/docs/user/quick-start/#installation
 sudo curl -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64"


### PR DESCRIPTION
We do not support newer versions than v0.25.1

Docs for the param: https://containerlab.dev/install/#install-script