### PR TITLE
Explicitly run metal-roles to pickup default variables.

### DIFF
--- a/deploy_control_plane.yaml
+++ b/deploy_control_plane.yaml
@@ -10,6 +10,8 @@
   roles:
     - name: ansible-common
       tags: always
+    - name: metal-roles
+      tags: always
     - name: ingress-controller
       tags: ingress-controller
     - name: metal-roles/control-plane/roles/prepare

--- a/deploy_partition.yaml
+++ b/deploy_partition.yaml
@@ -30,6 +30,8 @@
   roles:
     - name: ansible-common
       tags: always
+    - name: metal-roles
+      tags: always
     - name: metal-roles/partition/roles/dhcp
       tags: dhcp
     - name: metal-roles/partition/roles/pixiecore


### PR DESCRIPTION
For some reason this is required since the update to Ansible 9.