### PR TITLE
Use ext4 options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ metal-hammer*
 requirements.yaml
 .extra_vars.yaml
 sonic-vs.img
+*.bak

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ YQ=docker run --rm -i -v $(shell pwd):/workdir mikefarah/yq:3 /bin/sh -c
 KINDCONFIG := $(or $(KINDCONFIG),control-plane/kind.yaml)
 KUBECONFIG := $(shell pwd)/.kubeconfig
 
+MKE2FS_CONFIG := $(shell pwd)/mke2fs.conf
 # Default values
 CONTAINERLAB=$(shell which containerlab)
 

--- a/mke2fs.conf
+++ b/mke2fs.conf
@@ -1,0 +1,12 @@
+[defaults]
+	base_features = sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr
+	default_mntopts = acl,user_xattr
+	enable_periodic_fsck = 0
+	blocksize = 4096
+	inode_size = 256
+	inode_ratio = 16384
+
+[fs_types]
+	ext4 = {
+		features = has_journal,extent,huge_file,flex_bg,64bit,dir_nlink,extra_isize
+	}


### PR DESCRIPTION
When firecracker creates a blockdevice for KVM it formats it with EXT4. The options for the filesystems are normally in `/etc/mke2fs.conf` . On my system (ARCH) i have the settings

~~~
ext4 = {
  features = has_journal,extent,huge_file,flex_bg,metadata_csum,metadata_csum_seed,64bit,dir_nlink,extra_isize,orphan_file
}
~~~

After the creation firecracker exports the contents of the given VM-container-image to this blockdevice and starts a KVM process. 

In our case the VM is a very old cumulus image and the kernel in this image cannot handle the mountoption `metadata_csum` so the VM does not start and the whole minilab does not work.

This PR bundles a custom configuration file which is referenced by `MKE2FS_CONFIG` in the makefile, so all processes started by the Make-process will inherit this.

In cases where one already has a blockdevice with this new mount-option: you can remove the device from `/var/lib/firecracker` (if you do nothing with firecracker except minilab, you can simply delete all contents). after this, start minilab and firecracker will create a new blockdevice with ext4 but not the problematic FS-options.