### PR TITLE
Cumulus repo keys have expired.

### DIFF
--- a/deploy_partition.yaml
+++ b/deploy_partition.yaml
@@ -8,11 +8,13 @@
 - name: deploy docker
   hosts: leaves
   pre_tasks:
-    - name: update cumulus repo key
-      apt_key:
-        url: http://repo3.cumulusnetworks.com/public-key/repo3-2023-key
-        validate_certs: false
-        state: present
+    # the following task is not required as long as we do not install something from the cumulus repositories, for which all the keys are expired now
+    # the one from here has also expired on 9th Apr 2024: https://docs.nvidia.com/networking-ethernet-software/knowledge-base/Installing-and-Upgrading/Upgrading/Update-Expired-GPG-Keys/#package-upgrade-from-cumulus-linux-37x-to-3716
+    # - name: update cumulus repo key
+    #   apt_key:
+    #     url: http://repo3.cumulusnetworks.com/public-key/repo3-2023-key
+    #     validate_certs: false
+    #     state: present
     - name: unpack jessie fixes
       command: tar xf /root/jessie-apt-transport-fix.tar.gz
     - name: install apt-transport


### PR DESCRIPTION
We cannot use the prolonged repo key for 2023 anymore and it seems there will not be a new one. We cannot install packages from the Cumulus 3 repository anymore (without allowing untrusted sources).

```
❯ curl -qsSL http://repo3.cumulusnetworks.com/public-key/repo3-2023-key | gpg -    
gpg: WARNING: no command supplied.  Trying to guess what you mean ...
pub   rsa4096 2023-04-10 [SC] [expired: 2024-04-09]
      892D312684AAC54BEA60B4EEF1FECF020EA75A38
uid           Cumulus Linux 3.0 Package Repository Automatic Signing Key (2023) <support@cumulusnetworks.com>
sub   rsa4096 2023-04-14 [E] [expired: 2024-04-13]
