### PR TITLE
allow to build/push images into the leaf VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,11 @@ ssh-leafconfig:
 	@grep "Host leaf01" ~/.ssh/config || echo -e "Host leaf01\n    StrictHostKeyChecking no\n    IdentityFile $(shell pwd)/files/ssh/id_rsa\n" >>~/.ssh/config
 	@grep "Host leaf02" ~/.ssh/config || echo -e "Host leaf02\n    StrictHostKeyChecking no\n    IdentityFile $(shell pwd)/files/ssh/id_rsa\n" >>~/.ssh/config
 
+.PHONY: docker-leaf01
 docker-leaf01:
 	@echo "export DOCKER_HOST=ssh://root@leaf01/var/run/docker.sock"
+
+.PHONY: docker-leaf02
 docker-leaf02:
 	@echo "export DOCKER_HOST=ssh://root@leaf02/var/run/docker.sock"
 

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,16 @@ ls: env
 
 ## SWITCH MANAGEMENT ##
 
+.PHONY: ssh-leafconfig
+ssh-leafconfig:
+	@grep "Host leaf01" ~/.ssh/config || echo -e "Host leaf01\n    StrictHostKeyChecking no\n    IdentityFile $(shell pwd)/files/ssh/id_rsa\n" >>~/.ssh/config
+	@grep "Host leaf02" ~/.ssh/config || echo -e "Host leaf02\n    StrictHostKeyChecking no\n    IdentityFile $(shell pwd)/files/ssh/id_rsa\n" >>~/.ssh/config
+
+docker-leaf01:
+	@echo "export DOCKER_HOST=ssh://root@leaf01/var/run/docker.sock"
+docker-leaf02:
+	@echo "export DOCKER_HOST=ssh://root@leaf02/var/run/docker.sock"
+
 .PHONY: ssh-leaf01
 ssh-leaf01:
 	ssh -o StrictHostKeyChecking=no -o "PubkeyAcceptedKeyTypes +ssh-rsa" -i files/ssh/id_rsa root@leaf01


### PR DESCRIPTION
This PR allows the local developer to do

~~~
$ make ssh-leafconfig
$ eval `make docker-leaf01` 
~~~

and now the DOCKER_HOST points to the docker daemon of leaf01. One can now build local images (for example a test-image of `metal-core`) and build this image inside the leaf01. After a restart of the service inside the VM one can test the image without using a custom registry or pushing untested changes to build a public image.
