### PR TITLE
Use a nginx container to test outgoing traffic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,11 +239,11 @@ ssh-machine:
 	))
 	ssh -F files/ssh/config $(machine) $(COMMAND)
 
-.PHONY: connect-to-cloudflare
-connect-to-cloudflare:
-	@echo "Attempting to connect to Cloudflare..."
+.PHONY: connect-to-www
+connect-to-www:
+	@echo "Attempting to connect to container www..."
 	@for i in $$(seq 1 $(MAX_RETRIES)); do \
-		if $(MAKE) ssh-machine COMMAND="sudo curl --connect-timeout 1 --fail --silent https://1.1.1.1" > /dev/null 2>&1; then \
+		if $(MAKE) ssh-machine COMMAND="sudo curl --connect-timeout 1 --fail --silent http://203.0.113.3" > /dev/null 2>&1; then \
 			echo "Connected successfully"; \
 			exit 0; \
 		else \

--- a/files/rules.yaml
+++ b/files/rules.yaml
@@ -1,5 +1,11 @@
 ---
 egress:
+  - comment: allow outgoing http
+    ports:
+      - 80
+    protocol: TCP
+    to:
+      - 0.0.0.0/0
   - comment: allow outgoing https
     ports:
       - 443

--- a/mini-lab.cumulus.yaml
+++ b/mini-lab.cumulus.yaml
@@ -38,10 +38,17 @@ topology:
       binds:
         - /dev:/dev
         - scripts:/mini-lab
-
+    www:
+      kind: linux
+      image: docker.io/library/nginx:alpine-slim
+      network-mode: none
+      exec:
+        - ip addr add 203.0.113.3/24 dev ext
+        - ip route add 203.0.113.128/25 via 203.0.113.2 dev ext
   links:
     - endpoints: ["inet:ext", "mini_lab_ext:inet"]
       mtu: 9000
+    - endpoints: ["www:ext", "mini_lab_ext:www"]
     - endpoints: ["leaf01:swp1", "vms:lan0"]
     - endpoints: ["leaf02:swp1", "vms:lan1"]
     - endpoints: ["leaf01:swp2", "vms:lan2"]

--- a/mini-lab.sonic.yaml
+++ b/mini-lab.sonic.yaml
@@ -40,9 +40,17 @@ topology:
       binds:
         - /dev:/dev
         - scripts:/mini-lab
+    www:
+      kind: linux
+      image: docker.io/library/nginx:alpine-slim
+      network-mode: none
+      exec:
+        - ip addr add 203.0.113.3/24 dev ext
+        - ip route add 203.0.113.128/25 via 203.0.113.2 dev ext
   links:
     - endpoints: ["inet:ext", "mini_lab_ext:inet"]
       mtu: 9000
+    - endpoints: ["www:ext", "mini_lab_ext:www"]
     - endpoints: ["leaf01:eth1", "inet:eth1"]
     - endpoints: ["leaf02:eth1", "inet:eth2"]
     - endpoints: ["leaf01:eth2", "vms:lan0"]

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -43,7 +43,7 @@ done
 echo "$phoned/$minPhoned machines have phoned home"
 
 echo "Test connectivity to outside"
-make connect-to-cloudflare
+make connect-to-www
 
 echo "Test connectivity from outside"
 ssh -o StrictHostKeyChecking=no -o "PubkeyAcceptedKeyTypes +ssh-rsa" -i files/ssh/id_rsa metal@203.0.113.130 -C exit


### PR DESCRIPTION
Removes dependency on external servers and can be used to test ipv6.