### PR TITLE
Migrate to QEMU 9.1 by switching to bookworm backports

### DIFF
--- a/images/Dockerfile.vms
+++ b/images/Dockerfile.vms
@@ -1,6 +1,12 @@
-FROM ubuntu:20.04
+FROM docker.io/library/debian:bookworm-backports
 
-RUN apt update -y && \
-    apt install -y qemu-system-x86 ovmf ifupdown net-tools telnet
+RUN apt update && \
+    apt-get --no-install-recommends install --yes \
+        iproute2 \
+        ovmf \
+        python3 \
+        qemu-utils \
+        qemu-system-x86 \
+        telnet
 
-CMD ["/mini-lab/vms_entrypoint.sh"]
+ENTRYPOINT ["/mini-lab/vms_entrypoint.sh"]

--- a/images/sonic/Dockerfile
+++ b/images/sonic/Dockerfile
@@ -1,12 +1,12 @@
-FROM docker.io/library/debian:bookworm-slim
+FROM docker.io/library/debian:bookworm-backports
 
 ENV LIBGUESTFS_BACKEND=direct
 
 RUN apt-get update && \
     apt-get --no-install-recommends install --yes \
         curl \
+        iproute2 \
         linux-image-cloud-amd64 \
-        net-tools \
         python3 \
         python3-guestfs \
         qemu-system-x86 \

--- a/images/sonic/launch.py
+++ b/images/sonic/launch.py
@@ -50,6 +50,7 @@ class Qemu:
             '-smp', self._smp,
             '-display', 'none',
             '-enable-kvm',
+            '-nodefaults',
             '-machine', 'q35',
             '-name', self._name,
             '-m', self._memory,
@@ -61,7 +62,7 @@ class Qemu:
             with open(f'/sys/class/net/eth{i}/address', 'r') as f:
                 mac = f.read().strip()
             cmd.append('-device')
-            cmd.append(f'virtio-net,netdev=hn{i},mac={mac}')
+            cmd.append(f'virtio-net-pci,netdev=hn{i},mac={mac}')
             cmd.append(f'-netdev')
             cmd.append(f'tap,id=hn{i},ifname=tap{i},script=/mirror_tap_to_eth.sh,downscript=no')
 

--- a/scripts/manage_vms.py
+++ b/scripts/manage_vms.py
@@ -122,21 +122,22 @@ class Manager:
             "-name", machine.get("name"),
             "-uuid", machine.get("uuid"),
             "-m", machine.get("memory"),
-            "-boot", "n",
             "-cpu", "host",
-            "-drive", "if=virtio,format=qcow2,file={disk}".format(disk=machine.get("disk-path")),
-            "-drive", "if=pflash,format=raw,readonly,file=/usr/share/OVMF/OVMF_CODE.fd",
-            "-drive", "if=pflash,format=raw,readonly,file=/usr/share/OVMF/OVMF_VARS.fd",
-            "-serial", "telnet:127.0.0.1:{port},server,nowait".format(port=machine.get("serial-port")),
+            "-display", "none",
             "-enable-kvm",
-            "-nographic",
+            "-machine", "q35",
+            "-nodefaults",
+            "-drive", "if=virtio,format=qcow2,file={disk}".format(disk=machine.get("disk-path")),
+            "-drive", "if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd",
+            "-drive", "if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_VARS.fd",
+            "-serial", "telnet:127.0.0.1:{port},server,nowait".format(port=machine.get("serial-port")),
         ]
 
         for i in machine["lan_indices"]:
             with open(f'/sys/class/net/lan{i}/address', 'r') as f:
                 mac = f.read().strip()
             cmd.append('-device')
-            cmd.append(f'virtio-net,netdev=hn{i},mac={mac}')
+            cmd.append(f'virtio-net-pci,netdev=hn{i},mac={mac},romfile=')
             cmd.append(f'-netdev')
             cmd.append(f'tap,id=hn{i},ifname=tap{i},script=/mini-lab/mirror_tap_to_lan.sh,downscript=no')
 


### PR DESCRIPTION
## Description

Ubuntu 20.04 has QEMU 4.2
Bookworm has QEMU 7.2

The image size for `ghcr.io/metal-stack/mini-lab-vms` decreased from 452MB to 333MB, while `ghcr.io/metal-stack/mini-lab-sonic` increased from 2.57GB to 2.67GB. Both images now share the same base image.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You can add something to the release notes for the next metal-stack release (metal-stack/releases)? You can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

If your changes contain a breaking change, please add the following section:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```


### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
