### PR TITLE
Migrate from guestfs to nbdfuse to save 400 MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ partition: partition-bake
 .PHONY: partition-bake
 partition-bake: external_network
 	docker pull $(MINI_LAB_VM_IMAGE)
-#ifeq ($(MINI_LAB_FLAVOR),sonic)
-#	docker pull $(MINI_LAB_SONIC_IMAGE)
-#endif
+ifeq ($(MINI_LAB_FLAVOR),sonic)
+	docker pull $(MINI_LAB_SONIC_IMAGE)
+endif
 	@if ! sudo $(CONTAINERLAB) --topo $(LAB_TOPOLOGY) inspect | grep -i leaf01 > /dev/null; then \
 		sudo --preserve-env $(CONTAINERLAB) deploy --topo $(LAB_TOPOLOGY) --reconfigure && \
 		./scripts/deactivate_offloading.sh; fi

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ partition: partition-bake
 .PHONY: partition-bake
 partition-bake: external_network
 	docker pull $(MINI_LAB_VM_IMAGE)
-ifeq ($(MINI_LAB_FLAVOR),sonic)
-	docker pull $(MINI_LAB_SONIC_IMAGE)
-endif
+#ifeq ($(MINI_LAB_FLAVOR),sonic)
+#	docker pull $(MINI_LAB_SONIC_IMAGE)
+#endif
 	@if ! sudo $(CONTAINERLAB) --topo $(LAB_TOPOLOGY) inspect | grep -i leaf01 > /dev/null; then \
 		sudo --preserve-env $(CONTAINERLAB) deploy --topo $(LAB_TOPOLOGY) --reconfigure && \
 		./scripts/deactivate_offloading.sh; fi

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The mini-lab is a small, virtual setup to locally run the metal-stack. It deploy
 
 - Linux machine with hardware virtualization support
 - kvm as hypervisor for the VMs (you can check through the `kvm-ok` command)
+- the fuse kernel module needs to be loaded (you can check through the `lsmod | grep fuse` command)
 - [docker](https://www.docker.com/) >= 24.x.y (for using kind and our deployment base image)
 - [kind](https://github.com/kubernetes-sigs/kind/releases) == v0.23.0 (for hosting the metal control plane)
 - [containerlab](https://containerlab.dev/install/) >= v0.56.0

--- a/images/sonic/Dockerfile
+++ b/images/sonic/Dockerfile
@@ -5,10 +5,13 @@ ENV LIBGUESTFS_BACKEND=direct
 RUN apt-get update && \
     apt-get --no-install-recommends install --yes \
         curl \
+        fuse \
+        fuse2fs \
+        libnbd-bin \
+        nbdkit \
         iproute2 \
-        linux-image-cloud-amd64 \
         python3 \
-        python3-guestfs \
+        qemu-utils \
         qemu-system-x86 \
         telnet
 

--- a/images/sonic/launch.py
+++ b/images/sonic/launch.py
@@ -146,7 +146,7 @@ def initial_configuration(path: str) -> None:
 
     config_db['DEVICE_METADATA']['localhost']['hostname'] = socket.gethostname()
     config_db['DEVICE_METADATA']['localhost']['mac'] = get_mac_address('eth0')
-    cidr = get_ip_address('eth0'), '/16'
+    cidr = get_ip_address('eth0') + '/16'
     config_db['MGMT_INTERFACE'] = {
         f'eth0|{cidr}': {
             'gwaddr': get_default_gateway()


### PR DESCRIPTION
## Description

Only small improvements of startup time of the leaves in low one digit range.

Guestfs also lacks an interface to set xattr for whiteout files in the overlay filesystem.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You can add something to the release notes for the next metal-stack release (metal-stack/releases)? You can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

If your changes contain a breaking change, please add the following section:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```


### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
