### PR TITLE
Increase vtep MTU rate.

### DIFF
--- a/roles/sonic/tasks/main.yaml
+++ b/roles/sonic/tasks/main.yaml
@@ -11,3 +11,6 @@
   delay: 3
   register: result
   until: result.rc == 0
+
+- name: Increase vtep mtu rate to 9100
+  command: ip link set dev vtep-1001 mtu 9100


### PR DESCRIPTION
## Description

This we found out during development of the [cluster-api-provider-metal-stack](https://github.com/metal-stack/cluster-api-provider-metal-stack). The API server could not be reached on the machine from the host because packages were not arriving when HTTPS was being used.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
