### PR TITLE
Test on latest OS images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,12 @@ MINI_LAB_FLAVOR := $(or $(MINI_LAB_FLAVOR),sonic)
 MINI_LAB_VM_IMAGE := $(or $(MINI_LAB_VM_IMAGE),ghcr.io/metal-stack/mini-lab-vms:latest)
 MINI_LAB_SONIC_IMAGE := $(or $(MINI_LAB_SONIC_IMAGE),ghcr.io/metal-stack/mini-lab-sonic:latest)
 
-MACHINE_OS=ubuntu-24.04
+MACHINE_OS=debian-12.0
 MAX_RETRIES := 30
 
 # Machine flavors
 ifeq ($(MINI_LAB_FLAVOR),cumulus)
+MACHINE_OS=ubuntu-24.04
 LAB_MACHINES=machine01,machine02
 LAB_TOPOLOGY=mini-lab.cumulus.yaml
 VRF=vrf20

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ docker compose run --rm metalctl machine create \
         --hostname machine \
         --project 00000000-0000-0000-0000-000000000000 \
         --partition mini-lab \
-        --image ubuntu-20.04 \
+        --image ubuntu-24.04 \
         --size v1-small-x86 \
         --networks <network-ID>
 
@@ -138,7 +138,7 @@ docker compose run --rm metalctl machine create \
         --hostname fw \
         --project 00000000-0000-0000-0000-000000000000 \
         --partition mini-lab \
-        --image firewall-ubuntu-2.0 \
+        --image firewall-ubuntu-3.0 \
         --size v1-small-x86 \
         --networks internet-mini-lab,$(privatenet)
 ```
@@ -148,7 +148,7 @@ See the installation process in action
 ```bash
 make console-machine01/02
 ...
-Ubuntu 20.04 machine ttyS0
+Ubuntu 24.04 machine ttyS0
 
 machine login:
 ```
@@ -157,9 +157,9 @@ Two machines are now installed and have status "Phoned Home"
 
 ```bash
 docker compose run --rm metalctl machine ls
-ID                                          LAST EVENT   WHEN   AGE     HOSTNAME  PROJECT                               SIZE          IMAGE                             PARTITION
-00000000-0000-0000-0000-000000000001        Phoned Home  2s     21s     machine   00000000-0000-0000-0000-000000000000  v1-small-x86  Ubuntu 20.04 20200331             mini-lab
-00000000-0000-0000-0000-000000000002        Phoned Home  8s     18s     fw        00000000-0000-0000-0000-000000000000  v1-small-x86  Firewall 2 Ubuntu 20200730        mini-lab
+ID                                          LAST EVENT   WHEN   AGE     HOSTNAME  PROJECT                               SIZE          IMAGE               PARTITION
+00000000-0000-0000-0000-000000000001        Phoned Home  2s     21s     machine   00000000-0000-0000-0000-000000000000  v1-small-x86  Ubuntu 24.04        mini-lab
+00000000-0000-0000-0000-000000000002        Phoned Home  8s     18s     fw        00000000-0000-0000-0000-000000000000  v1-small-x86  Firewall 3 Ubuntu   mini-lab
 ```
 
 Login with user name metal and the console password from
@@ -180,7 +180,7 @@ Reinstall a machine with
 
 ```bash
 docker compose run --rm metalctl machine reinstall \
-        --image ubuntu-20.04 \
+        --image ubuntu-24.04 \
         00000000-0000-0000-0000-000000000001
 ```
 

--- a/inventories/group_vars/control-plane/metal.yml
+++ b/inventories/group_vars/control-plane/metal.yml
@@ -11,19 +11,23 @@ metal_api_admin_key: metal-admin
 
 metal_api_nsq_tcp_address: nsqd:4150
 
-metal_api_latest_os_image_release_name: "{{ (lookup('url', 'https://api.github.com/repos/metal-stack/metal-images/releases/latest', headers=({'authorization': 'Bearer ' + github_runner_token} if github_runner_token else {})) | from_json).get('name') }}"
-
 metal_api_images:
 - id: firewall-ubuntu-3.0
   name: Firewall 3 Ubuntu
   description: Firewall 3 Ubuntu Latest Release
-  url: https://images.metal-stack.io/metal-os/{{ metal_api_latest_os_image_release_name }}/firewall/3.0-ubuntu/img.tar.lz4
+  url: https://images.metal-stack.io/metal-os/stable/firewall/3.0-ubuntu/img.tar.lz4
   features:
     - firewall
 - id: ubuntu-24.04
   name: Ubuntu 24.04
   description: Ubuntu 24.04 Latest Release
-  url: https://images.metal-stack.io/metal-os/{{ metal_api_latest_os_image_release_name }}/ubuntu/24.04/img.tar.lz4
+  url: https://images.metal-stack.io/metal-os/stable/ubuntu/24.04/img.tar.lz4
+  features:
+    - machine
+- id: debian-12.0
+  name: Debian 12
+  description: Debian 12 Latest Release
+  url: https://images.metal-stack.io/metal-os/stable/debian/12/img.tar.lz4
   features:
     - machine
 


### PR DESCRIPTION
## Description

I think we already did this once in the past and I would like to bring it back.

Main motivation is that with the current approach we often hit Github API rate limiting for determining the latest OS image version through our CI. 

Also the mini-lab integration tests are likely to become more important in the future because we want to test the Gardener integration components in there, too. Probably also CAPI support will be added.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
