### PR TITLE
Draft: Local dex to be able to test OIDC integration

### DIFF
--- a/deploy_control_plane.yaml
+++ b/deploy_control_plane.yaml
@@ -22,6 +22,8 @@
       tags: auditing
     - name: metal-roles/control-plane/roles/metal
       tags: metal
+    - name: roles/dex
+      tags: auth
 
 - name: deploy gardener
   import_playbook: deploy_gardener.yaml

--- a/inventories/group_vars/control-plane/metal.yml
+++ b/inventories/group_vars/control-plane/metal.yml
@@ -112,6 +112,13 @@ metal_masterdata_api_tenants:
     version: 0
   name: metal-stack
   iam_config:
+    issuer_config:
+      url: http://auth.{{ metal_control_plane_ingress_dns }}:8080
+      client_id: "metal-stack"
+    idm_config:
+      idm_type: "ldap"
+    group_config:
+      namespace_max_length: 20
   description: metal-stack tenant, which is provider
 
 metal_masterdata_api_projects:

--- a/roles/dex/defaults/main.yaml
+++ b/roles/dex/defaults/main.yaml
@@ -1,0 +1,4 @@
+metal_auth_dex_host: auth.{{ metal_control_plane_ingress_dns }}
+metal_auth_dex_issuer_url: http://auth.{{ metal_control_plane_ingress_dns }}:8080
+metal_auth_dex_client_secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+metal_auth_dex_namespace: "{{ metal_control_plane_namespace }}"

--- a/roles/dex/tasks/main.yaml
+++ b/roles/dex/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Deploy dex
+  kubernetes.core.k8s:
+    apply: true
+    namespace: dex
+    template:
+      - path: dex.yaml.j2

--- a/roles/dex/templates/dex.yaml.j2
+++ b/roles/dex/templates/dex.yaml.j2
@@ -1,0 +1,145 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: {{ metal_auth_dex_namespace }}
+  labels:
+    app.kubernetes.io/name: dex
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dex
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dex
+    spec:
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex
+          args:
+            - dex
+            - serve
+            - /dex-config/config.yaml
+          volumeMounts:
+            - name: configuration
+              readonly: true
+              mountPath: /dex-config
+            - name: data
+              mountPath: /data
+          ports:
+            - name: web
+              containerPort: 5556
+            - name: grpc
+              containerPort: 5557
+            - name: telemetry
+              containerPort: 5558
+
+      volumes:
+        - name: configuration
+          secret:
+            secretName: dex-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+        - name: data
+          persistentVolumeClaim:
+            claimName: dex-db-pvc
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-config
+  namespace: {{ metal_auth_dex_namespace }}
+  labels:
+    app.kubernetes.io/part-of: dex
+stringData:
+  config.yaml: |
+    issuer: http://auth.172.17.0.1.nip.io:8080/dex
+
+    storage:
+      type: sqlite3
+      config:
+        file: /data/sqlite.db
+
+    web:
+      http: 0.0.0.0:5556
+    telemetry:
+      http: 0.0.0.0:5558
+    grpc:
+      addr: 0.0.0.0:5557
+    staticClients:
+      - id: metal-stack
+        public: true
+        name: "metal-stack"
+        secret: {{ metal_auth_dex_client_secret }}
+
+    enablePasswordDB: true
+
+    staticPasswords:
+      - email: "admin@metal-stack.io"
+        # password in bcrypt
+        hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+        username: "admin"
+        userID: "00000000-0000-0000-0000-000000000001"
+        groups:
+        - metal-stack_all-all-admin
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dex-db-pvc
+  namespace: {{ metal_auth_dex_namespace }}
+  labels:
+    app.kubernetes.io/part-of: dex
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: {{ metal_auth_dex_namespace }}
+  labels:
+    app.kubernetes.io/name: dex
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dex
+  ports:
+    - name: web
+      port: 5556
+      targetPort: 5556
+    - name: grpc
+      port: 5557
+      targetPort: 5557
+    - name: telemetry
+      port: 5558
+      targetPort: 5558
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dex
+  namespace: {{ metal_auth_dex_namespace }}
+  labels:
+    app.kubernetes.io/name: dex
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: {{ metal_auth_dex_host }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: dex
+                port:
+                  name: web
+            path: /
+            pathType: Prefix

--- a/roles/dex/templates/dex.yaml.j2
+++ b/roles/dex/templates/dex.yaml.j2
@@ -84,7 +84,7 @@ stringData:
         username: "admin"
         userID: "00000000-0000-0000-0000-000000000001"
         groups:
-        - metal-stack_all-all-admin
+        - metal-stack_maas-all-all-admin
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description

Adds a local dex to test OIDC in the future. Currently defunct because dex cannot add groups to static passwords.

I don't expect this to change in the near future, so this PR is here for future reference.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
