### PR TITLE
Fix semver image of ubuntu

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -71,7 +71,6 @@ jobs:
         tags: ${{ env.MINI_LAB_SONIC_IMAGE }}
         cache-from: type=registry,ref=${{ env.MINI_LAB_SONIC_IMAGE }}
         cache-to: type=inline
-      if: ${{ matrix.flavors.name == 'sonic' }}
 
     - name: Run integration tests
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ MAX_RETRIES := 30
 
 # Machine flavors
 ifeq ($(MINI_LAB_FLAVOR),cumulus)
-MACHINE_OS=ubuntu-24.04
+MACHINE_OS=ubuntu-24.4
 LAB_MACHINES=machine01,machine02
 LAB_TOPOLOGY=mini-lab.cumulus.yaml
 VRF=vrf20

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ docker compose run --rm metalctl machine create \
         --hostname machine \
         --project 00000000-0000-0000-0000-000000000000 \
         --partition mini-lab \
-        --image ubuntu-24.04 \
+        --image ubuntu-24.4 \
         --size v1-small-x86 \
         --networks <network-ID>
 
@@ -180,7 +180,7 @@ Reinstall a machine with
 
 ```bash
 docker compose run --rm metalctl machine reinstall \
-        --image ubuntu-24.04 \
+        --image ubuntu-24.4 \
         00000000-0000-0000-0000-000000000001
 ```
 

--- a/inventories/group_vars/control-plane/metal.yml
+++ b/inventories/group_vars/control-plane/metal.yml
@@ -18,7 +18,7 @@ metal_api_images:
   url: https://images.metal-stack.io/metal-os/stable/firewall/3.0-ubuntu/img.tar.lz4
   features:
     - firewall
-- id: ubuntu-24.04
+- id: ubuntu-24.4
   name: Ubuntu 24.04
   description: Ubuntu 24.04 Latest Release
   url: https://images.metal-stack.io/metal-os/stable/ubuntu/24.04/img.tar.lz4

--- a/inventories/group_vars/examples/sample_fsl.yaml
+++ b/inventories/group_vars/examples/sample_fsl.yaml
@@ -21,7 +21,7 @@ metal_api_filesystemlayouts:
       - c1-xlarge-x86
     images:
       debian: "<= 10.0.{{ fsl.legacy_image_patch_version }}"
-      ubuntu: "<= 20.04.{{ fsl.legacy_image_patch_version }}"
+      ubuntu: "<= 20.4.{{ fsl.legacy_image_patch_version }}"
       centos: "<= 7.0.{{ fsl.legacy_image_patch_version }}"
   filesystems:
     - path: "/boot/efi"
@@ -70,7 +70,7 @@ metal_api_filesystemlayouts:
       - s1-large-x86
     images:
         debian: ">= 10.0.{{ fsl.new_image_patch_version }}"
-        ubuntu: ">= 20.04.{{ fsl.new_image_patch_version }}"
+        ubuntu: ">= 20.4.{{ fsl.new_image_patch_version }}"
         centos: ">= 7.0.{{ fsl.new_image_patch_version }}"
   filesystems:
     - path: "/boot/efi"
@@ -130,7 +130,7 @@ metal_api_filesystemlayouts:
       - s2-xlarge-x86
     images:
       debian: "<= 10.0.{{ fsl.legacy_image_patch_version }}"
-      ubuntu: "<= 20.04.{{ fsl.legacy_image_patch_version }}"
+      ubuntu: "<= 20.4.{{ fsl.legacy_image_patch_version }}"
   filesystems:
     - path: "/boot/efi"
       device: "/dev/sde1"


### PR DESCRIPTION
## Description

metal-api will now error out if the image version is not semver compatibel. This is the case for all image versions which have numbers with leading zeros like 24.04.

### Breaking Change

```BREAKING_CHANGE
A change in the semver library that is used by metal-stack and in the Gardener project forces us to rename the identifiers that we typically use for OS images like Ubuntu 24.04. The library now requires stricter semantic versions, not allow leading zeroes in version segments. 

In case you use for example `ubuntu-24.04.20250228` as an ID for an `image` in the metal-api, this needs to become `ubuntu-24.4.20250228`. 

In order to introduce the new identifier-format, before updating to this release of metal-stack, an image has to be created following the new version format. This image then co-exists with the old image format. After this, all machines referencing the old image must be reprovisioned with the new image ID format.

After all the references were migrated to the new image format, the old versions must be removed from the metal-api before upgrading to this release. Please adapt your deployments accordingly.

Unfortunately, there is no other way to migrate this ID in any other way than forking the Gardener project, which we did not want to do. If you encounter bigger issues with this step, please contact us in our Slack channel.
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
