### PR TITLE
Lower default for backup objects

### DIFF
--- a/inventories/group_vars/control-plane/auditing.yaml
+++ b/inventories/group_vars/control-plane/auditing.yaml
@@ -4,3 +4,5 @@ auditing_timescaledb_resources: {}
 
 auditing_meili_storage_size: 10Gi
 auditing_meili_resources: {}
+
+auditing_meili_backup_restore_sidecar_object_max_keep: 10

--- a/inventories/group_vars/control-plane/ipam_db.yaml
+++ b/inventories/group_vars/control-plane/ipam_db.yaml
@@ -3,3 +3,5 @@ ipam_db_storage_size: 200Mi
 ipam_db_backup_restore_sidecar_provider: local
 
 ipam_db_resources: {}
+
+ipam_db_backup_restore_sidecar_object_max_keep: 10

--- a/inventories/group_vars/control-plane/masterdata_db.yaml
+++ b/inventories/group_vars/control-plane/masterdata_db.yaml
@@ -3,3 +3,5 @@ masterdata_db_storage_size: 200Mi
 masterdata_db_backup_restore_sidecar_provider: local
 
 masterdata_db_resources: {}
+
+masterdata_db_backup_restore_sidecar_object_max_keep: 10

--- a/inventories/group_vars/control-plane/metal_db.yaml
+++ b/inventories/group_vars/control-plane/metal_db.yaml
@@ -5,3 +5,5 @@ metal_db_expose_frontend: yes
 
 metal_db_resources: {}
 metal_db_storage_size: 100Mi
+
+metal_db_backup_restore_sidecar_object_max_keep: 10


### PR DESCRIPTION
## Description

Apply a default value of 10 objects to keep for backups for the sidecar containers.

References: https://github.com/metal-stack/metal-roles/pull/370#issuecomment-2761472874

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
