### PR TITLE
Put virtual-garden admin into seeds group.

### DIFF
--- a/files/certs/virtual-admin/client.json
+++ b/files/certs/virtual-admin/client.json
@@ -9,7 +9,7 @@
     {
       "C": "DE",
       "L": "Munich",
-      "O": "system:masters",
+      "O": "gardener.cloud:system:seeds",
       "OU": "DevOps",
       "ST": "Bavaria"
     }


### PR DESCRIPTION
## Description

This change is required for g/g v1.112 where a validating webhook forbids manipulating resources in the virtual garden in case a user does not belong to the gardener seed group. This is a workaround until we migrated to the Gardener Operator where this issue gets resolved properly.

### Required Actions

```REQUIRED_ACTIONS
In order to roll out Gardener v1.112, it is required to re-generate the admin kubeconfig of the virtual garden and make the admin user belong to gardener seeds group. Otherwise, the Gardenlets, which currently use this admin kubeconfig, are not able to reconcile the seeds anymore. 

A template of how to generate the certificate for the admin kubeconfig can be looked up in https://github.com/metal-stack/mini-lab/pull/233. Existing admin kubeconfigs with this approach still work but they cannot modify resources like `ConfigMaps` anymore in the virtual garden.

Please note, that this approach is only a temporary workaround until we migrated our setup to the Gardener Operator. This is planned after we released support with Gardener v1.113. After this, the admin kubeconfig will be managed differently through the operator and it will also be rotated automatically.
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
