### PR TITLE
Inline IP masquerade for SONiC switches

### DIFF
--- a/inventories/group_vars/sonic/main.yaml
+++ b/inventories/group_vars/sonic/main.yaml
@@ -17,8 +17,6 @@ sonic_mgmt_vrf: false
 
 sonic_nameservers: "{{ router_nameservers }}"
 
-sonic_ip_masquerade: true
-
 sonic_vlans:
   - id: 4000
     ip: "{{ metal_core_cidr }}"

--- a/roles/sonic/tasks/main.yaml
+++ b/roles/sonic/tasks/main.yaml
@@ -11,3 +11,17 @@
   delay: 3
   register: result
   until: result.rc == 0
+
+- name: Activate IP MASQUERADE on eth0
+  ansible.builtin.iptables:
+    chain: POSTROUTING
+    jump: MASQUERADE
+    out_interface: eth0
+    table: nat
+
+- name: Activate ipv4 forwarding on eth0
+  ansible.posix.sysctl:
+    name: net.ipv4.conf.eth0.forwarding
+    reload: no
+    sysctl_set: yes
+    value: "1"


### PR DESCRIPTION
## Description

IP masquerade is only needed in mini-lab and no other deployments. Therefore, the `sonic_ip_masquerade` variable will be removed from the sonic role in the future and the masquerade tasks are performed in the mini-lab directly.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
