### PR TITLE
README.md: Add jq to apt install

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Here is some code that should help you to set up most of the requirements:
 sudo ufw status
 sudo ufw allow from 172.17.0.0/16
 
-# Install kvm
-sudo apt install -y git curl qemu qemu-kvm haveged
+# Install required tools / kvm
+sudo apt install -y git curl qemu qemu-kvm haveged jq
 
 # Install Docker
 curl -fsSL https://get.docker.com | sh


### PR DESCRIPTION
I just ran mini-lab on a newly installed workstation where I didn't happen to have `jq` installed yet; noticed it in `make` failing.