### PR TITLE
chore: prepare kamaji tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -30,9 +30,10 @@ jobs:
     - name: Make tag
       run: |
         IMAGE_TAG=$([ "${GITHUB_EVENT_NAME}" == 'pull_request' ] && echo ${GITHUB_HEAD_REF##*/} || echo "latest")
+        SHA_TAG=${GITHUB_SHA::8}
 
         echo "MINI_LAB_VM_IMAGE=ghcr.io/metal-stack/mini-lab-vms:${IMAGE_TAG}" >> $GITHUB_ENV
-        echo "MINI_LAB_SONIC_IMAGE=ghcr.io/metal-stack/mini-lab-sonic:${IMAGE_TAG}" >> $GITHUB_ENV
+        echo "MINI_LAB_VM_IMAGE_SHA=ghcr.io/metal-stack/mini-lab-vms:${SHA_TAG}" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -44,7 +45,9 @@ jobs:
         pull: true
         push: true
         sbom: true
-        tags: ${{ env.MINI_LAB_VM_IMAGE }}
+        tags: |
+          ${{ env.MINI_LAB_VM_IMAGE }}
+          ${{ env.MINI_LAB_VM_IMAGE_SHA }}
         cache-from: type=registry,ref=${{ env.MINI_LAB_VM_IMAGE }}
         cache-to: type=inline
 
@@ -66,9 +69,10 @@ jobs:
     - name: Make tag
       run: |
         IMAGE_TAG=$([ "${GITHUB_EVENT_NAME}" == 'pull_request' ] && echo ${GITHUB_HEAD_REF##*/} || echo "latest")
+        SHA_TAG=${GITHUB_SHA::8}
 
-        echo "MINI_LAB_VM_IMAGE=ghcr.io/metal-stack/mini-lab-vms:${IMAGE_TAG}" >> $GITHUB_ENV
         echo "MINI_LAB_SONIC_IMAGE=ghcr.io/metal-stack/mini-lab-sonic:${IMAGE_TAG}" >> $GITHUB_ENV
+        echo "MINI_LAB_SONIC_IMAGE_SHA=ghcr.io/metal-stack/mini-lab-sonic:${SHA_TAG}" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -80,7 +84,9 @@ jobs:
         pull: true
         push: true
         sbom: true
-        tags: ${{ env.MINI_LAB_SONIC_IMAGE }}
+        tags: |
+          ${{ env.MINI_LAB_SONIC_IMAGE }}
+          ${{ env.MINI_LAB_SONIC_IMAGE_SHA }}
         cache-from: type=registry,ref=${{ env.MINI_LAB_SONIC_IMAGE }}
         cache-to: type=inline
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -30,10 +30,12 @@ jobs:
     - name: Make tag
       run: |
         IMAGE_TAG=$([ "${GITHUB_EVENT_NAME}" == 'pull_request' ] && echo ${GITHUB_HEAD_REF##*/} || echo "latest")
-        SHA_TAG=${GITHUB_SHA::8}
+        SHA_TAG=${COMMIT_SHA::8}
 
         echo "MINI_LAB_VM_IMAGE=ghcr.io/metal-stack/mini-lab-vms:${IMAGE_TAG}" >> $GITHUB_ENV
         echo "MINI_LAB_VM_IMAGE_SHA=ghcr.io/metal-stack/mini-lab-vms:${SHA_TAG}" >> $GITHUB_ENV
+      env:
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -69,10 +71,12 @@ jobs:
     - name: Make tag
       run: |
         IMAGE_TAG=$([ "${GITHUB_EVENT_NAME}" == 'pull_request' ] && echo ${GITHUB_HEAD_REF##*/} || echo "latest")
-        SHA_TAG=${GITHUB_SHA::8}
+        SHA_TAG=${COMMIT_SHA::8}
 
         echo "MINI_LAB_SONIC_IMAGE=ghcr.io/metal-stack/mini-lab-sonic:${IMAGE_TAG}" >> $GITHUB_ENV
         echo "MINI_LAB_SONIC_IMAGE_SHA=ghcr.io/metal-stack/mini-lab-sonic:${SHA_TAG}" >> $GITHUB_ENV
+      env:
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/compose.yaml
+++ b/compose.yaml
@@ -148,5 +148,5 @@ volumes:
 
 networks:
   kind:
-    name: kind
+    name: ${KIND_EXPERIMENTAL_DOCKER_NETWORK:-kind}
     external: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
       # - ${HOME}/.ansible/roles/metal-ansible-modules:/root/.ansible/roles/metal-ansible-modules:ro
       # - ${HOME}/git/github.com/metal-stack/helm-charts:/helm-charts:ro
     environment:
-      - ANSIBLE_DISPLAY_SKIPPED_HOSTS=${ANSIBLE_DISPLAY_SKIPPED_HOSTS}
+      - ANSIBLE_DISPLAY_SKIPPED_HOSTS=${ANSIBLE_DISPLAY_SKIPPED_HOSTS:-false}
       - ANSIBLE_INVENTORY=inventories/control-plane.yaml
       - KUBECONFIG=/mini-lab/.kubeconfig
       - K8S_AUTH_KUBECONFIG=/mini-lab/.kubeconfig
@@ -45,7 +45,7 @@ services:
       # - ${HOME}/.ansible/roles/metal-roles:/root/.ansible/roles/metal-roles:ro
       # - ${HOME}/.ansible/roles/metal-ansible-modules:/root/.ansible/roles/metal-ansible-modules:ro
     environment:
-      - ANSIBLE_DISPLAY_SKIPPED_HOSTS=${ANSIBLE_DISPLAY_SKIPPED_HOSTS}
+      - ANSIBLE_DISPLAY_SKIPPED_HOSTS=${ANSIBLE_DISPLAY_SKIPPED_HOSTS:-false}
       - ANSIBLE_INVENTORY=inventories/partition.yaml,clab-mini-lab/ansible-inventory.yml
       - CI=${CI}
       - DOCKER_HUB_USER=${DOCKER_HUB_USER}

--- a/mini-lab.kamaji.yaml
+++ b/mini-lab.kamaji.yaml
@@ -61,6 +61,20 @@ topology:
         UUID: 00000000-0000-0000-0000-000000000002
         QEMU_CPU_CORES: 2
         QEMU_DISK_SIZE: 20G
+    machine03:
+      group: machines
+      image: ${MINI_LAB_VM_IMAGE}
+      env:
+        UUID: 00000000-0000-0000-0000-000000000003
+        QEMU_CPU_CORES: 2
+        QEMU_DISK_SIZE: 20G
+    machine04:
+      group: machines
+      image: ${MINI_LAB_VM_IMAGE}
+      env:
+        UUID: 00000000-0000-0000-0000-000000000004
+        QEMU_CPU_CORES: 2
+        QEMU_DISK_SIZE: 20G
   links:
     - endpoints: ["exit:mini_lab_ext", "mini_lab_ext:exit"]
       mtu: 9000
@@ -70,5 +84,9 @@ topology:
     - endpoints: ["leaf02:Ethernet0", "machine01:lan1"]
     - endpoints: ["leaf01:Ethernet1", "machine02:lan0"]
     - endpoints: ["leaf02:Ethernet1", "machine02:lan1"]
+    - endpoints: ["leaf01:Ethernet2", "machine03:lan0"]
+    - endpoints: ["leaf02:Ethernet2", "machine03:lan1"]
+    - endpoints: ["leaf01:Ethernet3", "machine04:lan0"]
+    - endpoints: ["leaf02:Ethernet3", "machine04:lan1"]
     - endpoints: ["leaf01:Ethernet120", "exit:eth1"]
     - endpoints: ["leaf02:Ethernet120", "exit:eth2"]


### PR DESCRIPTION
## Description

I want to introduce smoke tests for the Kamaji flavor inside the capi-lab repo.

Therefore I want to reuse the MINI_LAB_VM_IMAGE and MINI_LAB_SONIC_IMAGE from exact that commit, that is referenced in the mini-lab sub module.

This allows that the tests inside the capi-lab run on the mini-lab image version we actually reference, that we don't have to seperately build them and that the image is available in the future.

I also increased the number of machines in the Kamaji topology to 4, so I can bootstrap two tenant clusters in different namespaces.

References:

- #287 


#### Used AI-Tools ✨

- Copilot for auto-completion and research