### PR TITLE
feat: allow using local checkouts of dependencies via env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,21 @@ else
   DOCKER_COMPOSE_RUN_ARG=--rm
 endif
 
+COMPOSE_ARGS := -f compose.yaml
+
+# in DEV mode, include an override compose file for each MINI_LAB_* checkout
+# path that is set, to mount it into the deployment containers.
+ifeq ($(DEV),true)
+COMPOSE_ARGS += $(if $(MINI_LAB_METAL_ROLES),-f compose.dev/metal-roles.yaml)
+COMPOSE_ARGS += $(if $(MINI_LAB_ANSIBLE_COMMON),-f compose.dev/ansible-common.yaml)
+COMPOSE_ARGS += $(if $(MINI_LAB_METAL_ANSIBLE_MODULES),-f compose.dev/metal-ansible-modules.yaml)
+COMPOSE_ARGS += $(if $(MINI_LAB_HELM_CHARTS),-f compose.dev/helm-charts.yaml)
+endif
+
 .PHONY: up
 up: env gen-certs control-plane-bake partition-bake
 	@chmod 600 files/ssh/id_ed25519
-	docker compose up --pull=always --abort-on-container-failure --remove-orphans --force-recreate control-plane partition
+	docker compose $(COMPOSE_ARGS) up --pull=always --abort-on-container-failure --remove-orphans --force-recreate control-plane partition
 	@$(MAKE)	--no-print-directory	start-machines
 # for some reason an allocated machine will not be able to phone home
 # without restarting the metal-core
@@ -98,11 +109,11 @@ roll-certs:
 
 .PHONY: control-plane
 control-plane: control-plane-bake env
-	docker compose up --remove-orphans --force-recreate control-plane
+	docker compose $(COMPOSE_ARGS) up --remove-orphans --force-recreate control-plane
 
 .PHONY: create-proxy-registries
 create-proxy-registries:
-	docker compose up -d --force-recreate proxy-docker proxy-ghcr proxy-gcr proxy-k8s proxy-quay
+	docker compose $(COMPOSE_ARGS) up -d --force-recreate proxy-docker proxy-ghcr proxy-gcr proxy-k8s proxy-quay
 
 .PHONY: control-plane-bake
 control-plane-bake:
@@ -116,7 +127,7 @@ control-plane-bake:
 
 .PHONY: partition
 partition: partition-bake
-	docker compose up --remove-orphans --force-recreate partition
+	docker compose $(COMPOSE_ARGS) up --remove-orphans --force-recreate partition
 
 .PHONY: partition-bake
 partition-bake: external_network
@@ -159,7 +170,7 @@ cleanup: cleanup-control-plane cleanup-partition
 .PHONY: cleanup-control-plane
 cleanup-control-plane:
 	kind delete cluster --name metal-control-plane
-	docker compose down
+	docker compose $(COMPOSE_ARGS) down
 	rm -f $(KUBECONFIG)
 
 .PHONY: cleanup-partition

--- a/README.md
+++ b/README.md
@@ -190,6 +190,47 @@ There are make targets to handle the power state of a machine:
 make power-<on,reset,off>-<machine name>
 ```
 
+## Development
+If you want to contribute to the _metal-stack_ project, you can use the mini-lab as a local development environment. It allows you to quickly test changes to the _metal-stack_ components without needing any external clusters or hardware. 
+You can also use it to test changes to the Ansible roles and modules used by the _metal-stack_.
+
+### Release vector
+
+You can configure the `mini-lab` to deploy specific custom or unreleased images of components by adjusting the variables in [inventories/group_vars/all/release_vector.yaml](inventories/group_vars/all/release_vector.yaml).
+
+For example, to quickly deploy `metal-api` with a custom branch tag, you can add or uncomment specific release tags in that file:
+
+```yaml
+metal_api_image_tag: my-feat-branch
+# metal_core_image_tag: v1.2.3
+```
+
+Further overrides can be looked up in `metal-roles` where the mapping is defined in [common/roles/defaults/defaults/main.yaml](https://github.com/metal-stack/metal-roles/blob/master/common/roles/defaults/defaults/main.yaml).
+
+### Using local checkouts of dependencies
+
+By default, the `mini-lab` runs with pre-packaged Ansible roles and modules. 
+If you want to use local checkouts of dependencies for development, you must start the `mini-lab` with `DEV=true`:
+
+```bash
+DEV=true make up
+```
+
+When `DEV=true` is set, you can provide the following environment variables to map local directories into the containers. Each variable is independent — only the ones you set will be mounted (via a matching override file from `compose.dev/`):
+
+- `MINI_LAB_METAL_ROLES`: path to local `metal-roles` (includes `compose.dev/metal-roles.yaml`)
+- `MINI_LAB_ANSIBLE_COMMON`: path to local `ansible-common` (includes `compose.dev/ansible-common.yaml`)
+- `MINI_LAB_METAL_ANSIBLE_MODULES`: path to local `metal-ansible-modules` (includes `compose.dev/metal-ansible-modules.yaml`)
+- `MINI_LAB_HELM_CHARTS`: path to local `helm-charts` (includes `compose.dev/helm-charts.yaml`)
+
+Example:
+
+```bash
+export MINI_LAB_METAL_ROLES=${HOME}/src/github.com/metal-stack/metal-roles
+export DEV=true
+make up
+```
+
 ## Flavors
 
 All available mini-lab flavors are listed below:

--- a/compose.dev/ansible-common.yaml
+++ b/compose.dev/ansible-common.yaml
@@ -1,0 +1,8 @@
+---
+services:
+  control-plane:
+    volumes:
+      - ${MINI_LAB_ANSIBLE_COMMON}:/root/.ansible/roles/ansible-common:ro
+  partition:
+    volumes:
+      - ${MINI_LAB_ANSIBLE_COMMON}:/root/.ansible/roles/ansible-common:ro

--- a/compose.dev/helm-charts.yaml
+++ b/compose.dev/helm-charts.yaml
@@ -1,0 +1,5 @@
+---
+services:
+  control-plane:
+    volumes:
+      - ${MINI_LAB_HELM_CHARTS}:/helm-charts:ro

--- a/compose.dev/metal-ansible-modules.yaml
+++ b/compose.dev/metal-ansible-modules.yaml
@@ -1,0 +1,8 @@
+---
+services:
+  control-plane:
+    volumes:
+      - ${MINI_LAB_METAL_ANSIBLE_MODULES}:/root/.ansible/roles/metal-ansible-modules:ro
+  partition:
+    volumes:
+      - ${MINI_LAB_METAL_ANSIBLE_MODULES}:/root/.ansible/roles/metal-ansible-modules:ro

--- a/compose.dev/metal-roles.yaml
+++ b/compose.dev/metal-roles.yaml
@@ -1,0 +1,8 @@
+---
+services:
+  control-plane:
+    volumes:
+      - ${MINI_LAB_METAL_ROLES}:/root/.ansible/roles/metal-roles:ro
+  partition:
+    volumes:
+      - ${MINI_LAB_METAL_ROLES}:/root/.ansible/roles/metal-roles:ro

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,12 +6,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
       - .:/mini-lab
-      # for developing role dependencies
-      # TODO: make this a switch
-      # - ${HOME}/.ansible/roles/ansible-common:/root/.ansible/roles/ansible-common:ro
-      # - ${HOME}/.ansible/roles/metal-roles:/root/.ansible/roles/metal-roles:ro
-      # - ${HOME}/.ansible/roles/metal-ansible-modules:/root/.ansible/roles/metal-ansible-modules:ro
-      # - ${HOME}/git/github.com/metal-stack/helm-charts:/helm-charts:ro
     environment:
       - ANSIBLE_DISPLAY_SKIPPED_HOSTS=${ANSIBLE_DISPLAY_SKIPPED_HOSTS:-false}
       - ANSIBLE_INVENTORY=inventories/control-plane.yaml
@@ -39,11 +33,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
       - .:/mini-lab
-      # for developing role dependencies
-      # TODO: make this a switch
-      # - ${HOME}/.ansible/roles/ansible-common:/root/.ansible/roles/ansible-common:ro
-      # - ${HOME}/.ansible/roles/metal-roles:/root/.ansible/roles/metal-roles:ro
-      # - ${HOME}/.ansible/roles/metal-ansible-modules:/root/.ansible/roles/metal-ansible-modules:ro
     environment:
       - ANSIBLE_DISPLAY_SKIPPED_HOSTS=${ANSIBLE_DISPLAY_SKIPPED_HOSTS:-false}
       - ANSIBLE_INVENTORY=inventories/partition.yaml,clab-mini-lab/ansible-inventory.yml


### PR DESCRIPTION
## Description
This PR tries to improve the handling of local dependency checkouts.
Users now do not have to change the compose files when using local dependencies for e.g. `metal-roles`. 

Part of #291 

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- Claude Opus 4.7 was used for README improvements and auto-completion

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
