### PR TITLE
fix: install missing frr-reload.service on dell_sonic leaves

### DIFF
--- a/deploy_partition.yaml
+++ b/deploy_partition.yaml
@@ -20,6 +20,10 @@
   hosts: dell_sonic
   any_errors_fatal: true
   become: true
+  handlers:
+    - name: reload systemd daemon
+      systemd:
+        daemon_reload: true
   tasks:
     - name: Check for bgpd.conf presence
       ansible.builtin.stat:
@@ -37,6 +41,15 @@
         user: root
         state: present
         key: "{{ lookup('file', 'ssh/id_ed25519.pub') }}"
+
+    - name: Install frr-reload.service
+      copy:
+        src: /root/.ansible/roles/metal-roles/partition/roles/sonic-config/files/frr-reload.service
+        dest: /etc/systemd/system/frr-reload.service
+        remote_src: false
+      notify:
+        - reload systemd daemon
+      changed_when: true
 
     - name: Activate IP MASQUERADE on eth0
       ansible.builtin.iptables:


### PR DESCRIPTION
## Description
The dell_sonic integration runs failed because of a missing dell_sonic frr-reload.service according to #279.
I tracked down the recent commits when the pipe started failing:
The `metal-core` Ansible role doesn't deploy the `frr-reload-service` anymore: https://github.com/metal-stack/metal-roles/pull/479/changes.
The `sonic` Ansible role was deprecated and replaced with `sonic-config`, which deploys it now - but not on dell_sonic switches in the mini-lab: https://github.com/metal-stack/mini-lab/pull/272/changes#diff-e5a9ca7487c5ffd979ceb6ae78ca57e297f588eb7c5a4678c2396730566d4664.

When installing it on the dell_sonic switches, tests run fine again.

References:
Needed by https://github.com/metal-stack/cluster-api-provider-metal-stack/pull/137 
Closes #279 


<!-- If not used, delete the next section.
#### Used AI-Tools ✨

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
