### PR TITLE
Update debian, disable secure cookie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MINI_LAB_VM_IMAGE := $(or $(MINI_LAB_VM_IMAGE),ghcr.io/metal-stack/mini-lab-vms:
 MINI_LAB_SONIC_IMAGE := $(or $(MINI_LAB_SONIC_IMAGE),ghcr.io/metal-stack/mini-lab-sonic:latest)
 MINI_LAB_DELL_SONIC_VERSION := $(or $(MINI_LAB_DELL_SONIC_VERSION),4.5.1)
 
-MACHINE_OS=debian-12.0
+MACHINE_OS=debian-13.0
 MAX_RETRIES := 30
 
 # Machine flavors

--- a/inventories/group_vars/control_plane/metal.yml
+++ b/inventories/group_vars/control_plane/metal.yml
@@ -24,6 +24,7 @@ metal_apiserver_oidc_end_session_url: "https://zitadel.{{ metal_control_plane_in
 
 metal_apiserver_redis_password: change-me-soon
 metal_apiserver_admin_subjects: "admin@metal-stack.zitadel.172.17.0.1.nip.io@openid-connect"
+metal_apiserver_secure_cookie: false
 
 metal_api_images:
   - id: firewall-ubuntu-3.0
@@ -38,10 +39,10 @@ metal_api_images:
     url: https://images.metal-stack.io/metal-os/stable/ubuntu/24.04/img.tar.lz4
     features:
       - machine
-  - id: debian-12.0
-    name: Debian 12
-    description: Debian 12 Latest Release
-    url: https://images.metal-stack.io/metal-os/stable/debian/12/img.tar.lz4
+  - id: debian-13.0
+    name: Debian 13
+    description: Debian 13 Latest Release
+    url: https://images.metal-stack.io/metal-os/stable/debian/13/img.tar.lz4
     features:
       - machine
 


### PR DESCRIPTION
## Description

- Allow setting the secure cookie flag for the metal-apiserver
- default to debian-13

depends on:
- [ ] https://github.com/metal-stack/metal-roles/pull/620
- [x] https://github.com/metal-stack/helm-charts/pull/162

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
