### PR TITLE
Example for metal-roles override

### DIFF
--- a/inventories/group_vars/all/release_vector.yaml
+++ b/inventories/group_vars/all/release_vector.yaml
@@ -38,7 +38,7 @@ metal_stack_release_vectors:
 ##
 
 # ansible_common_version:
-# metal_roles_version:
+# metal_roles_version: pr-<pr-number-and-title>
 # metal_ansible_modules_version:
 
 ##


### PR DESCRIPTION
## Description

With the changes introduced in https://github.com/metal-stack/metal-roles/pull/653 the override for the metal-roles in the `release_vector.yaml` changed. This pull request provides information how the reference must look like.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
