### PR TITLE
Fix route reconciliation by enabling fpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,21 +79,13 @@ up: env gen-certs verify-deployment-image control-plane-bake partition-bake
 	@chmod 600 files/ssh/id_ed25519
 	docker compose $(COMPOSE_ARGS) up --pull=always --abort-on-container-failure --remove-orphans --force-recreate control-plane partition
 	@$(MAKE)	--no-print-directory	start-machines
-# for some reason an allocated machine will not be able to phone home
-# without restarting the metal-core
-# TODO: should be investigated and fixed if possible
-# check that underlay gets working
-	sleep 10
-	ssh -F files/ssh/config leaf01 'systemctl restart metal-core'
-	ssh -F files/ssh/config leaf02 'systemctl restart metal-core'
-
-# for community SONiC versions > 202311 a bgp restart is needed in the virtual environment
-# TODO: should be investigated and fixed if possible
-ifeq ($(filter $(MINI_LAB_FLAVOR),dell_sonic capms_dell_sonic),)
-	sleep 15
-	ssh -F files/ssh/config leaf01 'systemctl restart bgp'
-	ssh -F files/ssh/config leaf02 'systemctl restart bgp'
-endif
+# --- restart workarounds DISABLED for the startup-ordering / healthcheck fix test ---
+# The leaf `systemctl restart metal-core` + `restart bgp` band-aids below are exactly
+# what the images/sonic startup fix aims to make unnecessary; they are disabled here so
+# they don't mask the result. Restore with: git checkout Makefile
+# (was: sleep 10; restart metal-core on leaf01/leaf02; then for community SONiC,
+#  sleep 15; restart bgp on leaf01/leaf02)
+# --- end disabled ---
 
 .PHONY: restart
 restart: down up

--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,13 @@ up: env gen-certs verify-deployment-image control-plane-bake partition-bake
 	@chmod 600 files/ssh/id_ed25519
 	docker compose $(COMPOSE_ARGS) up --pull=always --abort-on-container-failure --remove-orphans --force-recreate control-plane partition
 	@$(MAKE)	--no-print-directory	start-machines
-# --- restart workarounds DISABLED for the startup-ordering / healthcheck fix test ---
-# The leaf `systemctl restart metal-core` + `restart bgp` band-aids below are exactly
-# what the images/sonic startup fix aims to make unnecessary; they are disabled here so
-# they don't mask the result. Restore with: git checkout Makefile
-# (was: sleep 10; restart metal-core on leaf01/leaf02; then for community SONiC,
-#  sleep 15; restart bgp on leaf01/leaf02)
-# --- end disabled ---
+
+# on old dell_sonic flavor metal-core needs a restart for nodes to register
+ifneq ($(filter $(MINI_LAB_FLAVOR),dell_sonic capms_dell_sonic),)
+	sleep 10
+	ssh -F files/ssh/config leaf01 'systemctl restart metal-core'
+	ssh -F files/ssh/config leaf02 'systemctl restart metal-core'
+endif
 
 .PHONY: restart
 restart: down up

--- a/deploy_partition.yaml
+++ b/deploy_partition.yaml
@@ -132,8 +132,33 @@
       when: monitoring_enabled
       tags: sonic-exporter
 
-- name: Deploy metal-core
-  hosts: leaves
+# So, route propagation was broken in community sonic for a while now. Turns out
+# during a change in upstream sonic some time in the end of 2024 sonic switched
+# the module used for FRR->fpmsyncd communication, which does not provide a
+# default connection endpoint. We just needed to add `fpm address 127.0.0.1`
+# to the frr.conf template and could remove all route-propagation related 
+# workarounds
+- name: Deploy metal-core (SONiC with dplane_fpm_sonic)
+  hosts: leaves:!dell_sonic
+  any_errors_fatal: true
+  become: true
+  pre_tasks:
+    - name: copy custom sonic_frr.tpl with fpm configured
+      ansible.builtin.copy:
+        dest: /sonic_frr.tpl
+        src: /mini-lab/files/sonic_frr_with_fpm.tpl
+  roles:
+    - name: ansible-common
+      tags: always
+    - name: metal-roles/partition/roles/metal-core
+      tags: metal-core
+      vars:
+        metal_core_frr_tpl_file: /sonic_frr.tpl
+        metal_core_additional_volume_mounts:
+        - /sonic_frr.tpl:/sonic_frr.tpl
+
+- name: Deploy metal-core (Dell SONiC without dplane_fpm_sonic)
+  hosts: dell_sonic
   any_errors_fatal: true
   become: true
   pre_tasks:

--- a/files/sonic_frr_with_fpm.tpl
+++ b/files/sonic_frr_with_fpm.tpl
@@ -1,0 +1,179 @@
+{{- $ASN := .ASN -}}{{- $RouterId := .Loopback -}}! The frr version is not rendered since it seems to be optional.
+frr defaults datacenter
+fpm address 127.0.0.1
+hostname {{ .Name }}
+password zebra
+enable password zebra
+!
+agentx
+log syslog {{ .LogLevel }}
+log facility local4
+debug bgp updates
+debug bgp nht
+debug bgp update-groups
+debug bgp zebra
+debug zebra events
+debug zebra nexthop detail
+debug zebra rib detailed
+debug zebra nht detailed
+{{- range $vrf, $t := .Ports.Vrfs }}
+!
+vrf Vrf{{ $t.VNI }}
+ vni {{ $t.VNI }}
+ exit-vrf
+{{- end }}
+{{- range .Ports.Underlay }}
+!
+interface {{ . }}
+ ipv6 nd ra-interval 6
+ no ipv6 nd suppress-ra
+{{- end }}
+{{- range .Ports.Firewalls }}
+!
+interface {{ .Port }}
+ ipv6 nd ra-interval 6
+ no ipv6 nd suppress-ra
+{{- end }}
+{{- range $vrf, $t := .Ports.Vrfs }}
+{{- range $t.Neighbors }}
+!
+interface {{ . }} vrf {{ $vrf }}
+ ipv6 nd ra-interval 6
+ no ipv6 nd suppress-ra
+{{- end }}
+{{- end }}
+!
+router bgp {{ $ASN }}
+ bgp router-id {{ $RouterId }}
+ bgp bestpath as-path multipath-relax
+ neighbor FABRIC peer-group
+ neighbor FABRIC remote-as external
+ neighbor FABRIC timers 2 8
+ {{- range .Ports.Underlay }}
+ neighbor {{ . }} interface peer-group FABRIC
+ {{- end }}
+ neighbor FIREWALL peer-group
+ neighbor FIREWALL remote-as external
+ neighbor FIREWALL timers 2 8
+ {{- range .Ports.Firewalls }}
+ neighbor {{ .Port }} interface peer-group FIREWALL
+ {{- end }}
+ !
+ address-family ipv4 unicast
+  redistribute connected route-map DENY_MGMT
+  redistribute kernel route-map DENY_MGMT
+  neighbor FIREWALL allowas-in 2
+  {{- range $k, $f := .Ports.Firewalls }}
+  neighbor {{ $f.Port }} route-map fw-{{ $k }}-in in
+  {{- end }}
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  redistribute connected route-map DENY_MGMT
+  redistribute kernel route-map DENY_MGMT
+  neighbor FIREWALL allowas-in 2
+  # see https://docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-A.B.C.D-activate
+  # why activate is required
+  neighbor FIREWALL activate
+  {{- range $k, $f := .Ports.Firewalls }}
+  neighbor {{ $f.Port }} route-map fw-{{ $k }}-in in
+  {{- end }}
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  advertise-all-vni
+  neighbor FABRIC activate
+  neighbor FABRIC allowas-in 2
+  neighbor FIREWALL activate
+  neighbor FIREWALL allowas-in 2
+  {{- range $k, $f := .Ports.Firewalls }}
+  neighbor {{ $f.Port }} route-map fw-{{ $k }}-vni out
+  {{- end }}
+ exit-address-family
+!
+route-map DENY_MGMT deny 10
+  match interface eth0
+route-map DENY_MGMT permit 20
+!
+{{- range $k, $f := .Ports.Firewalls }}
+# route-maps for firewall@{{ $k }}
+        {{- range $f.IPPrefixLists }}
+ip prefix-list {{ .Name }} {{ .Spec }}
+        {{- end}}
+        {{- range $f.RouteMaps }}
+route-map {{ .Name }} {{ .Policy }} {{ .Order }}
+                {{- range .Entries }}
+ {{ . }}
+                {{- end }}
+        {{- end }}
+!
+{{- end }}
+{{- if .Ports.Eth0.Gateway }}
+ip route 0.0.0.0/0 {{ .Ports.Eth0.Gateway }} nexthop-vrf mgmt
+{{- end }}
+!
+{{- range $vrf, $t := .Ports.Vrfs }}
+router bgp {{ $ASN }} vrf {{ $vrf }}
+ bgp router-id {{ $RouterId }}
+ bgp bestpath as-path multipath-relax
+ neighbor MACHINE peer-group
+ neighbor MACHINE remote-as external
+ neighbor MACHINE timers 2 8
+ {{- range $t.Neighbors }}
+ neighbor {{ . }} interface peer-group MACHINE
+ {{- end }}
+ !
+ {{- if $t.Has4 }}
+ address-family ipv4 unicast
+  redistribute connected
+  neighbor MACHINE maximum-prefix 24000
+  {{- if gt (len $t.IPPrefixLists) 0 }}
+  neighbor MACHINE route-map {{ $vrf }}-in in
+  {{- end }}
+ exit-address-family
+ !
+ {{- end }}
+ {{- if $t.Has6 }}
+ address-family ipv6 unicast
+  redistribute connected
+  neighbor MACHINE maximum-prefix 24000
+  # see https://docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-A.B.C.D-activate
+  # why activate is required
+  neighbor MACHINE activate
+  {{- if gt (len $t.IPPrefixLists) 0 }}
+  neighbor MACHINE route-map {{ $vrf }}-in6 in
+  {{- end }}
+ exit-address-family
+ !
+ {{- end }}
+ address-family l2vpn evpn
+ {{- if $t.Has4 }}
+  advertise ipv4 unicast
+ {{- end }}
+ {{- if $t.Has6 }}
+  advertise ipv6 unicast
+ {{- end }}
+ exit-address-family
+!
+{{- if gt (len $t.IPPrefixLists) 0 }}
+# route-maps for {{ $vrf }}
+        {{- range $t.IPPrefixLists }}
+ip prefix-list {{ .Name }} {{ .Spec }}
+        {{- end}}
+        {{- range $t.RouteMaps }}
+route-map {{ .Name }} {{ .Policy }} {{ .Order }}
+                {{- range .Entries }}
+ {{ . }}
+                {{- end }}
+        {{- end }}
+!{{- end }}{{- end }}
+{{- if .SetSrcLoopback }}
+route-map RM_SET_SRC permit 10
+ set src {{ .Loopback }}
+exit
+!
+ip protocol bgp route-map RM_SET_SRC
+!
+{{- end }}
+line vty
+!

--- a/files/sonic_frr_with_fpm.tpl
+++ b/files/sonic_frr_with_fpm.tpl
@@ -1,5 +1,7 @@
 {{- $ASN := .ASN -}}{{- $RouterId := .Loopback -}}! The frr version is not rendered since it seems to be optional.
 frr defaults datacenter
+# This is the only line changed from upstream: https://github.com/metal-stack/metal-core/blob/master/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+# Follow-up issue: https://github.com/metal-stack/metal-core/issues/199
 fpm address 127.0.0.1
 hostname {{ .Name }}
 password zebra

--- a/images/sonic/Dockerfile
+++ b/images/sonic/Dockerfile
@@ -21,4 +21,6 @@ ENTRYPOINT ["/launch.py"]
 
 COPY mirror_tap_to_eth.sh mirror_tap_to_front_panel.sh port_config.ini launch.py /
 
-HEALTHCHECK --start-period=10s --interval=5s --retries=20 CMD test -f /healthy
+# Readiness now waits for the dataplane (front-panel LLDP), which converges later than the
+# mgmt plane, so allow more time before the container is considered unhealthy.
+HEALTHCHECK --start-period=30s --interval=5s --retries=40 CMD test -f /healthy

--- a/images/sonic/launch.py
+++ b/images/sonic/launch.py
@@ -102,8 +102,12 @@ def initial_configuration(g: GuestFS, hwsku: str) -> None:
 
     # Workaround: Speed up lldp startup by remove hardcoded wait of 90 seconds
     g.ln_s(linkname=systemd_system + 'aaastatsd.timer', target='/dev/null') # Radius
-    g.ln_s(linkname=systemd_system + 'featured.timer', target='/dev/null') # Feature handling not necessary
-    g.ln_s(linkname=systemd_system + 'hostcfgd.timer', target='/dev/null') # After boot Host configuration
+    # NOTE: featured.timer and hostcfgd.timer are intentionally NOT masked. They run
+    # SONiC's feature-manager and host-config reconciliation and provide the startup
+    # ordering that EVPN/FRR bring-up relies on. Masking them raced the remote L3VNI
+    # VTEP RMAC programming on the leaves, which then required a manual
+    # `systemctl restart bgp` to recover. lldp/pmon are still hand-wired below so they
+    # start immediately instead of waiting for featured's delayed timer.
     g.ln_s(linkname=systemd_system + 'rasdaemon.timer', target='/dev/null') # After boot Host configuration
     g.ln_s(linkname=systemd_system + 'tacacs-config.timer', target='/dev/null') # After boot Host configuration
     # Started by featured
@@ -203,11 +207,17 @@ def main():
     logger.info('Start QEMU')
     vm.start()
 
-    # SONiC will start sending LLDP packets after PortConfigDone is set in APPL database
-    logger.info('Wait until eth0 has an IPv4 address')
-    sniff(iface='eth0', filter='ether proto 0x88cc', stop_filter=has_an_IPv4_address('eth0'), store=0)
+    # Readiness: wait until SONiC forwards its own LLDP out a *front-panel* port, not just
+    # mgmt eth0. LLDP egress on a front-panel port requires PortConfigDone AND the port to
+    # be programmed/oper-up in the (v)ASIC dataplane, so this signals dataplane readiness
+    # instead of mgmt-plane-only readiness (which let the lab proceed, and metal-core
+    # configure the fabric, while the switch dataplane/EVPN was still converging).
+    # We match on SONiC's own mgmt address, so neighbor LLDP on the port is ignored.
+    dataplane_ifaces = get_ethernet_interfaces()
+    logger.info(f'Wait until a front-panel port forwards LLDP (dataplane up): {dataplane_ifaces}')
+    sniff(iface=dataplane_ifaces, filter='ether proto 0x88cc', stop_filter=has_an_IPv4_address('eth0'), store=0)
 
-    logger.info('eth0 has a configured IPv4 address')
+    logger.info('dataplane is forwarding LLDP')
     with open('/healthy', 'w'):
         pass
 

--- a/tasks/check_queued.yaml
+++ b/tasks/check_queued.yaml
@@ -21,13 +21,3 @@
   register: queued_check
   delay: 5
   changed_when: false
-
-- name: restart bgp
-  ansible.builtin.systemd:
-    name: bgp
-    state: restarted
-  when: queued_check.stdout == "true"
-
-- name: recheck for queued routes
-  include_tasks: tasks/check_queued.yaml
-  when: queued_check.stdout == "true"


### PR DESCRIPTION
## Description

Add a frr.conf template including `fpm address 127.0.0.1` to connect frr to the SONiC Forwarding Plane for upstream SONIC.

SONiC at some point in H2 2024 moved to their own FRR FPM module(Forwarding Plane Manager) called `dplane_fpm_sonic`. ([Design Doc](https://github.com/sonic-net/SONiC/blob/master/doc/sonic-fpm-module/frr_sonic_communication_channel.md)) Unsure if route propagation using the frr.conf template used by metal-core worked before that, but from this point on `fpm address 127.0.0.1` was strictly required for FRR/Zebra to push routes to the SONiC FPM.

This broke route propagation from FRR to the sonic forwarding plane, which was worked around by restarts of FRR and metal-core, that for some reason I do not yet understand, forced propagation into the forwarding plane. Maybe there is a workaround in metal-core that periodically/at restart copies routes from Zebra to the SONiC data plane?

All Broadcom/Dell/Edgecore SONIC Enterprise distributions we looked at are based on upstream SONIC 202211from before the switch to `dplane_fpm_sonic` and are incompatible with this setting. Although they show similar route propagation defects in certain circumstances, the root cause has to be something else. Best guesses are the old FRR version shipped in these enterprise sonics (FRR 8.2.2) or use of the old FRR fpm module, which was replaced with  `dplane_fpm_sonic` exactly because there were widespread issues with missing mandatory information for programming the sonic FPM.

Adding the config file override as a workaround for now until we figure out which SONiC versions and distributions are affected. Goal is to get this into the frr.conf templates in metal-roles/metal-core asap.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- Claude Opus 4.8 used for launch.py startup adjustments

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
